### PR TITLE
Add flag to pass user auth tokens at runtime

### DIFF
--- a/api/project.go
+++ b/api/project.go
@@ -5,7 +5,9 @@ import (
 	"github.com/unweave/cli/entity"
 )
 
-func (a *Api) GetUserProject(ctx context.Context, projectId string) (*entity.Project, error) {
+func (a *Api) GetUserProject(ctx context.Context, projectId string) (
+	*entity.Project, error,
+) {
 	req, err := a.NewAuthorizedGqlRequest(entity.GetProjectQuery, struct {
 		Id string `json:"id"`
 	}{
@@ -24,14 +26,14 @@ func (a *Api) GetUserProject(ctx context.Context, projectId string) (*entity.Pro
 	return &resp.Data, nil
 }
 
-func (a *Api) GetUserProjects(ctx context.Context) ([]entity.Project, error) {
+func (a *Api) GetUserProjects(ctx context.Context) ([]*entity.Project, error) {
 	req, err := a.NewAuthorizedGqlRequest(entity.GetProjectsQuery, struct{}{})
 	if err != nil {
 		return nil, err
 	}
 
 	var resp struct {
-		Data []entity.Project `json:"projects"`
+		Data []*entity.Project `json:"projects"`
 	}
 	if err = a.ExecuteGql(ctx, req, &resp); err != nil {
 		return nil, err

--- a/api/token.go
+++ b/api/token.go
@@ -21,14 +21,14 @@ func (a *Api) CreateUserToken(ctx context.Context) (*entity.UserToken, error) {
 	return &resp.Data, nil
 }
 
-func (a *Api) GetUserTokens(ctx context.Context) ([]entity.UserToken, error) {
+func (a *Api) GetUserTokens(ctx context.Context) ([]*entity.UserToken, error) {
 	req, err := a.NewAuthorizedGqlRequest(entity.GetUserTokensQuery, struct{}{})
 	if err != nil {
 		return nil, err
 	}
 
 	var resp struct {
-		Data []entity.UserToken `json:"userTokens"`
+		Data []*entity.UserToken `json:"userTokens"`
 	}
 	if err = a.ExecuteGql(ctx, req, &resp); err != nil {
 		return nil, err

--- a/api/token.go
+++ b/api/token.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+	"github.com/unweave/cli/entity"
+)
+
+func (a *Api) CreateUserToken(ctx context.Context) (*entity.UserToken, error) {
+	req, err := a.NewAuthorizedGqlRequest(entity.CreateUserTokenMutation, struct{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Data entity.UserToken `json:"createUserToken"`
+	}
+	if err = a.ExecuteGql(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp.Data, nil
+}
+
+func (a *Api) GetUserTokens(ctx context.Context) ([]entity.UserToken, error) {
+	req, err := a.NewAuthorizedGqlRequest(entity.GetUserTokensQuery, struct{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Data []entity.UserToken `json:"userTokens"`
+	}
+	if err = a.ExecuteGql(ctx, req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Data, nil
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -26,10 +26,10 @@ func (h *Handler) List(ctx context.Context, cmd *entity.Command) error {
 
 	fmt.Println("Projects:")
 	for _, p := range projects {
-		if path, ok := findLinkedPath(h.cfg.Root.Projects, p.Id); ok {
-			fmt.Printf("  %s \n\tID: %s \n\tPath: %s\n", p.Name, p.Id, path)
+		if path, ok := findLinkedPath(h.cfg.Root.Projects, p.ID); ok {
+			fmt.Printf("  %s \n\tID: %s \n\tPath: %s\n", p.Name, p.ID, path)
 		} else {
-			fmt.Printf("  %s \n\tID: %s \n\tPath: Not linked\n", p.Name, p.Id)
+			fmt.Printf("  %s \n\tID: %s \n\tPath: Not linked\n", p.Name, p.ID)
 		}
 	}
 

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/unweave/cli/entity"
+)
+
+func (h *Handler) CreateUserToken(ctx context.Context, cmd *entity.Command) error {
+	token, err := h.ctrl.CreateUserToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create new user token, %s", err)
+	}
+
+	fmt.Println("Created new user token:")
+	fmt.Printf("\t%s\n", token)
+	return nil
+}
+
+func (h *Handler) GetUserTokens(ctx context.Context, cmd *entity.Command) error {
+	tokens, err := h.ctrl.GetUserTokens(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch user tokens, %s", err)
+	}
+
+	for _, token := range tokens {
+		fmt.Printf("\t%s\n", token)
+	}
+	return nil
+}
+
+func CreateUserTokenCmd(cmd *cobra.Command, args []string) error {
+	h := New()
+	ctx := context.Background()
+	cmd.SilenceUsage = true
+	return h.CreateUserToken(ctx, &entity.Command{
+		Args: args,
+		Cmd:  cmd,
+	})
+}
+
+func GetUserTokensCmd(cmd *cobra.Command, args []string) error {
+	h := New()
+	ctx := context.Background()
+	cmd.SilenceUsage = true
+	return h.GetUserTokens(ctx, &entity.Command{
+		Args: args,
+		Cmd:  cmd,
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/unweave/cli/constants"
 	"github.com/unweave/cli/entity"
 	"os"
 )
@@ -74,5 +75,9 @@ func New() *Config {
 		panic(err)
 	}
 
+	// Override auth token if set manually at runtime
+	if constants.AuthToken != "" {
+		config.Root.User.Token = constants.AuthToken
+	}
 	return &config
 }

--- a/constants/env.go
+++ b/constants/env.go
@@ -1,4 +1,4 @@
 package constants
 
 var UnweaveEnv = "dev"
-
+var AuthToken = ""

--- a/controller/link.go
+++ b/controller/link.go
@@ -13,13 +13,13 @@ func (c *Controller) Link(ctx context.Context, projectId, path string) error {
 	}
 
 	config := entity.ProjectConfig{
-		Id: project.Id,
+		Id: project.ID,
 	}
 
 	err = c.cfg.AddProject(path, config)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Linked project %s with ID %s to path %s\n", project.Name, project.Id, path)
+	fmt.Printf("Linked project %s with ID %s to path %s\n", project.Name, project.ID, path)
 	return nil
 }

--- a/controller/project.go
+++ b/controller/project.go
@@ -5,6 +5,6 @@ import (
 	"github.com/unweave/cli/entity"
 )
 
-func (c *Controller) GetProjects(ctx context.Context) ([]entity.Project, error) {
+func (c *Controller) GetProjects(ctx context.Context) ([]*entity.Project, error) {
 	return c.api.GetUserProjects(ctx)
 }

--- a/controller/token.go
+++ b/controller/token.go
@@ -5,7 +5,7 @@ import (
 	"github.com/unweave/cli/entity"
 )
 
-func (c *Controller) GetUserTokens(ctx context.Context) ([]entity.UserToken, error) {
+func (c *Controller) GetUserTokens(ctx context.Context) ([]*entity.UserToken, error) {
 	return c.api.GetUserTokens(ctx)
 }
 

--- a/controller/token.go
+++ b/controller/token.go
@@ -1,0 +1,14 @@
+package controller
+
+import (
+	"context"
+	"github.com/unweave/cli/entity"
+)
+
+func (c *Controller) GetUserTokens(ctx context.Context) ([]entity.UserToken, error) {
+	return c.api.GetUserTokens(ctx)
+}
+
+func (c *Controller) CreateUserToken(ctx context.Context) (*entity.UserToken, error) {
+	return c.api.CreateUserToken(ctx)
+}

--- a/entity/project.go
+++ b/entity/project.go
@@ -3,12 +3,12 @@ package entity
 import "fmt"
 
 type Project struct {
-	Id   string `json:"id"`
+	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
 func (p Project) String() string {
-	return fmt.Sprintf("ID: %s, Name: %s", p.Id, p.Name)
+	return fmt.Sprintf("ID: %s, Name: %s", p.ID, p.Name)
 }
 
 const GetProjectQuery = `

--- a/entity/token.go
+++ b/entity/token.go
@@ -1,20 +1,45 @@
 package entity
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 )
 
 type UserToken struct {
-	ID          string `json:"id"`
-	DisplayName string `json:"displayName"`
-	ExpiresAt   int64  `json:"expiresAt"`
-	Token       string `json:"token"`
+	ID          string    `json:"id"`
+	DisplayName string    `json:"displayName"`
+	ExpiresAt   time.Time `json:"expiresAt"`
+	Token       string    `json:"token"`
 }
 
-func (u UserToken) String() string {
-	expires := time.UnixMilli(u.ExpiresAt)
-	expiresStr := expires.Format("2006-01-02 15:04:05")
+func (u *UserToken) UnmarshalJSON(b []byte) error {
+	type raw struct {
+		ID          string          `json:"id"`
+		DisplayName string          `json:"displayName"`
+		ExpiresAt   json.RawMessage `json:"expiresAt"`
+		Token       string          `json:"token"`
+	}
+	var r raw
+	if err := json.Unmarshal(b, &r); err != nil {
+		return err
+	}
+
+	var timeStamp int64
+	if err := json.Unmarshal(r.ExpiresAt, &timeStamp); err != nil {
+		return err
+	}
+
+	u.ID = r.ID
+	u.DisplayName = r.DisplayName
+	u.ExpiresAt = time.UnixMilli(timeStamp)
+	u.Token = r.Token
+
+	return nil
+}
+
+func (u *UserToken) String() string {
+	expiresStr := u.ExpiresAt.Format("2006-01-02 15:04:05")
 	return fmt.Sprintf("ID: %s, DisplayName: %s, ExpiresAt: %s", u.ID, u.DisplayName, expiresStr)
 }
 

--- a/entity/token.go
+++ b/entity/token.go
@@ -3,18 +3,20 @@ package entity
 import "fmt"
 
 type UserToken struct {
+	ID          string `json:"id"`
 	DisplayName string `json:"displayName"`
 	ExpiresAt   int    `json:"expiresAt"`
 	Token       string `json:"token"`
 }
 
 func (u UserToken) String() string {
-	return fmt.Sprintf("DisplayName: %s, ExpiresAt: %d", u.DisplayName, u.ExpiresAt)
+	return fmt.Sprintf("ID: %s, DisplayName: %s, ExpiresAt: %d", u.ID, u.DisplayName, u.ExpiresAt)
 }
 
 const GetUserTokensQuery = `
 	query GetUserTokens {
 		userTokens {
+			id
 			displayName
 			expiresAt
 		}
@@ -24,6 +26,7 @@ const GetUserTokensQuery = `
 const CreateUserTokenMutation = `
 	mutation CreateUserToken {
 		createUserToken {
+			id
 			displayName
 			expiresAt
 			token

--- a/entity/token.go
+++ b/entity/token.go
@@ -1,16 +1,21 @@
 package entity
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type UserToken struct {
 	ID          string `json:"id"`
 	DisplayName string `json:"displayName"`
-	ExpiresAt   int    `json:"expiresAt"`
+	ExpiresAt   int64  `json:"expiresAt"`
 	Token       string `json:"token"`
 }
 
 func (u UserToken) String() string {
-	return fmt.Sprintf("ID: %s, DisplayName: %s, ExpiresAt: %d", u.ID, u.DisplayName, u.ExpiresAt)
+	expires := time.UnixMilli(u.ExpiresAt)
+	expiresStr := expires.Format("2006-01-02 15:04:05")
+	return fmt.Sprintf("ID: %s, DisplayName: %s, ExpiresAt: %s", u.ID, u.DisplayName, expiresStr)
 }
 
 const GetUserTokensQuery = `

--- a/entity/token.go
+++ b/entity/token.go
@@ -1,0 +1,32 @@
+package entity
+
+import "fmt"
+
+type UserToken struct {
+	DisplayName string `json:"displayName"`
+	ExpiresAt   int    `json:"expiresAt"`
+	Token       string `json:"token"`
+}
+
+func (u UserToken) String() string {
+	return fmt.Sprintf("DisplayName: %s, ExpiresAt: %d", u.DisplayName, u.ExpiresAt)
+}
+
+const GetUserTokensQuery = `
+	query GetUserTokens {
+		userTokens {
+			displayName
+			expiresAt
+		}
+	}
+`
+
+const CreateUserTokenMutation = `
+	mutation CreateUserToken {
+		createUserToken {
+			displayName
+			expiresAt
+			token
+		}
+	}
+`

--- a/main.go
+++ b/main.go
@@ -22,6 +22,9 @@ func init() {
 	rootCmd.Flags().BoolP("version", "v", false, "Get the version of current Unweave CLI")
 	rootCmd.Flags().BoolVarP(&config.ShowConfig, "config", "c", false, "Show the current config")
 
+	// Accept token to be passed manually - this overrides the token saved from interactive login
+	rootCmd.PersistentFlags().StringVarP(&constants.AuthToken, "token", "t", "", "Use a specific token to authenticate - overrides login token")
+
 	// Connect
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "connect <project-id> <run-id>",

--- a/main.go
+++ b/main.go
@@ -94,6 +94,30 @@ func init() {
 	run.Flags().BoolVarP(&config.IsGpu, "gpu", "g", false, "Use GPU")
 	run.Flags().StringVarP(&config.ZeplProjectPath, "path", "p", "", "Path to an Unweave project to run")
 	rootCmd.AddCommand(run)
+
+	// Token
+	token := &cobra.Command{
+		Use:   "token",
+		Short: "Configure authentication tokens for the current user",
+		Args:  cobra.NoArgs,
+	}
+
+	getUserTokens := &cobra.Command{
+		Use:   "get-user-tokens",
+		Short: "Get all tokens for the current user",
+		RunE:  cmd.GetUserTokensCmd,
+	}
+	token.AddCommand(getUserTokens)
+
+	createUserToken := &cobra.Command{
+		Use:   "create-user-token",
+		Short: "Create a new token",
+		RunE:  cmd.CreateUserTokenCmd,
+	}
+	token.AddCommand(createUserToken)
+	rootCmd.AddCommand(token)
+
+	// TODO: add ability to fetch project tokens
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -22,12 +22,12 @@ func init() {
 	rootCmd.Flags().BoolP("version", "v", false, "Get the version of current Unweave CLI")
 	rootCmd.Flags().BoolVarP(&config.ShowConfig, "config", "c", false, "Show the current config")
 
-	// Accept token to be passed manually - this overrides the token saved from interactive login
-	rootCmd.PersistentFlags().StringVarP(&constants.AuthToken, "token", "t", "", "Use a specific token to authenticate - overrides login token")
+	// Accept token to be passed manually - this overrides the token saved from interactive loginCmd
+	rootCmd.PersistentFlags().StringVarP(&constants.AuthToken, "token", "t", "", "Use a specific token to authenticate - overrides loginCmd token")
 
 	// Connect
 	rootCmd.AddCommand(&cobra.Command{
-		Use:   "connect <project-id> <run-id>",
+		Use:   "connect <project-id> <runCmd-id>",
 		Short: "Connect to logs from a active session",
 		RunE:  cmd.ConnectCmd,
 		Args:  cobra.ExactArgs(2),
@@ -58,13 +58,13 @@ func init() {
 	})
 
 	// Login
-	login := &cobra.Command{
-		Use:   "login",
+	loginCmd := &cobra.Command{
+		Use:   "loginCmd",
 		Short: "Login through the browser or with an access token (--token)",
 		RunE:  cmd.LoginCmd,
 	}
-	rootCmd.AddCommand(login)
-	login.Flags().String("token", "", "--token <access_token>")
+	rootCmd.AddCommand(loginCmd)
+	loginCmd.Flags().String("token", "", "--token <access_token>")
 
 	// Logout
 	rootCmd.AddCommand(&cobra.Command{
@@ -82,7 +82,7 @@ func init() {
 	})
 
 	// Run
-	run := &cobra.Command{
+	runCmd := &cobra.Command{
 		Use:   "run [flags] [<command>]",
 		Short: "Run the current project in remotely with Unweave",
 		Example: "unweave run python train.py\n" +
@@ -91,31 +91,29 @@ func init() {
 		RunE: cmd.RunCmd,
 		Args: cobra.RangeArgs(1, 2),
 	}
-	run.Flags().BoolVarP(&config.IsGpu, "gpu", "g", false, "Use GPU")
-	run.Flags().StringVarP(&config.ZeplProjectPath, "path", "p", "", "Path to an Unweave project to run")
-	rootCmd.AddCommand(run)
+	runCmd.Flags().BoolVarP(&config.IsGpu, "gpu", "g", false, "Use GPU")
+	runCmd.Flags().StringVarP(&config.ZeplProjectPath, "path", "p", "", "Path to an Unweave project to run")
+	rootCmd.AddCommand(runCmd)
 
 	// Token
-	token := &cobra.Command{
+	tokenCmd := &cobra.Command{
 		Use:   "token",
 		Short: "Configure authentication tokens for the current user",
 		Args:  cobra.NoArgs,
 	}
 
-	getUserTokens := &cobra.Command{
+	tokenCmd.AddCommand(&cobra.Command{
 		Use:   "get-user-tokens",
 		Short: "Get all tokens for the current user",
 		RunE:  cmd.GetUserTokensCmd,
-	}
-	token.AddCommand(getUserTokens)
+	})
 
-	createUserToken := &cobra.Command{
+	tokenCmd.AddCommand(&cobra.Command{
 		Use:   "create-user-token",
 		Short: "Create a new token",
 		RunE:  cmd.CreateUserTokenCmd,
-	}
-	token.AddCommand(createUserToken)
-	rootCmd.AddCommand(token)
+	})
+	rootCmd.AddCommand(tokenCmd)
 
 	// TODO: add ability to fetch project tokens
 }


### PR DESCRIPTION
- Adds `--token` flag to optionally pass a user auth token with every command. This override the login token
- Adds new `token` command with `get-user-tokens` and `create-user-token` sub commands to configure auth tokens for the current user.

Resolves UNW-169