### PR TITLE
Update the SSH Interface to accept creating new resources

### DIFF
--- a/cmd/code.go
+++ b/cmd/code.go
@@ -36,24 +36,26 @@ func Code(cmd *cobra.Command, args []string) error {
 		isNew = true
 
 	} else {
+		var createNew bool
 
 		if execRef == "" {
-			var execs []types.Exec
-
-			execRef, execs, err = selectExec(cmd.Context(), "Select a session to connect to")
+			execRef, createNew, err = sessionSelectSSHExecRef(cmd, execRef, false)
 			if err != nil {
 				return err
 			}
-			if len(execs) == 0 {
-				ui.Errorf("❌ No active sessions found and no session name or ID provided. If " +
-					"you want to create a new session, use the --new flag.")
-				os.Exit(1)
-			}
 		}
 
-		execCh, errCh, err = session.Wait(ctx, execRef)
-		if err != nil {
-			return err
+		if createNew {
+			execCh, errCh, err = execCreateAndWatch(ctx, types.ExecConfig{}, types.GitConfig{})
+			if err != nil {
+				return err
+			}
+			isNew = true
+		} else {
+			execCh, errCh, err = session.Wait(ctx, execRef)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	for {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -157,4 +158,12 @@ func Exec(cmd *cobra.Command, args []string) error {
 
 	// TODO: subscribe to logs
 	return nil
+}
+
+// getExecs invokes the UnweaveClient and returns all container executions. Does not list terminated sessions by default
+func getExecs(ctx context.Context) ([]types.Exec, error) {
+	uwc := config.InitUnweaveClient()
+	listTerminated := config.All
+	owner, projectName := config.GetProjectOwnerAndName()
+	return uwc.Exec.List(ctx, owner, projectName, listTerminated)
 }

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"context"
+	"github.com/unweave/cli/ui"
+)
+
+// renderCobraSelection invokes Cobra to select an exec with a prompt, returns the index of the selected ID
+func renderCobraSelection(ctx context.Context, options []string, optIdByOptionIdx map[int]string, prompt string) (string, error) {
+	selected, err := ui.Select(prompt, options)
+	if err != nil {
+		return "", err
+	}
+	return optIdByOptionIdx[selected], nil
+}

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -278,44 +278,6 @@ func sessionTerminate(ctx context.Context, execID string) error {
 	return nil
 }
 
-func selectExec(ctx context.Context, msg string) (execID string, execs []types.Exec, err error) {
-	uwc := config.InitUnweaveClient()
-	listTerminated := config.All
-
-	owner, projectName := config.GetProjectOwnerAndName()
-	execs, err = uwc.Exec.List(ctx, owner, projectName, listTerminated)
-	if err != nil {
-		var e *types.Error
-		if errors.As(err, &e) {
-			uie := &ui.Error{Error: e}
-			fmt.Println(uie.Verbose())
-			os.Exit(1)
-		}
-		return "", nil, err
-	}
-
-	optionMap := make(map[int]string)
-	options := make([]string, len(execs))
-	if len(execs) == 0 {
-		return "", nil, nil
-	}
-
-	for idx, s := range execs {
-		txt := fmt.Sprintf("%s - %s - %s - (%s)", s.Name, s.Provider, s.NodeTypeID, s.Status)
-		options[idx] = txt
-		optionMap[idx] = s.ID
-	}
-
-	selected, err := ui.Select(msg, options)
-	if err != nil {
-		return "", nil, err
-	}
-
-	execID = optionMap[selected]
-
-	return execID, execs, nil
-}
-
 func SessionTerminate(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
 

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -288,8 +288,19 @@ func SessionTerminate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) == 0 {
-		var execs []types.Exec
-		execID, execs, _ = selectExec(cmd.Context(), "Select session to terminate")
+		execs, err := getExecs(cmd.Context())
+		if err != nil {
+			var e *types.Error
+			if errors.As(err, &e) {
+				uie := &ui.Error{Error: e}
+				fmt.Println(uie.Verbose())
+				os.Exit(1)
+			}
+			return err
+		}
+
+		opts, execIdByOpts := formatExecCobraOpts(execs)
+		execID, _ = selectExec(cmd.Context(), opts, execIdByOpts, "Select session to terminate")
 
 		if len(execs) == 0 {
 			ui.Attentionf("No active sessions found")

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -385,7 +385,7 @@ func getExecs(ctx context.Context) ([]types.Exec, error) {
 	return uwc.Exec.List(ctx, owner, projectName, listTerminated)
 }
 
-// selectExec invokes Cobra to select an exec with a prompt, returns the selected ID
+// selectExec invokes Cobra to select an exec with a prompt msg, returns the selected ID
 func selectExec(ctx context.Context, options []string, execIdByOptIdx map[int]string, msg string) (execID string, err error) {
 	selected, err := ui.Select(msg, options)
 	if err != nil {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -386,10 +386,10 @@ func getExecs(ctx context.Context) ([]types.Exec, error) {
 }
 
 // selectExec invokes Cobra to select an exec with a prompt, returns the selected ID
-func selectExec(ctx context.Context, options []string, idByOptionIdx map[int]string, msg string) (execID string, err error) {
+func selectExec(ctx context.Context, options []string, execIdByOptIdx map[int]string, msg string) (execID string, err error) {
 	selected, err := ui.Select(msg, options)
 	if err != nil {
 		return "", err
 	}
-	return idByOptionIdx[selected], nil
+	return execIdByOptIdx[selected], nil
 }

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -331,7 +331,7 @@ func SessionTerminate(cmd *cobra.Command, args []string) error {
 // sessionSelectSSHExecRef selects an exec id from all sessions in the Unweave environment or whether to create a new
 // provides an option to create a new Exec an error or exits if unrecoverable
 func sessionSelectSSHExecRef(cmd *cobra.Command, execRef string, allowNew bool) (string, bool, error) {
-	const newSessionOpt = "create a new session"
+	const newSessionOpt = "✨  Create a new session"
 
 	execs, err := getExecs(cmd.Context())
 	if err != nil {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -300,7 +300,7 @@ func SessionTerminate(cmd *cobra.Command, args []string) error {
 		}
 
 		opts, execIdByOpts := formatExecCobraOpts(execs)
-		execID, _ = selectExec(cmd.Context(), opts, execIdByOpts, "Select session to terminate")
+		execID, _ = renderCobraSelection(cmd.Context(), opts, execIdByOpts, "Select session to terminate")
 
 		if len(execs) == 0 {
 			ui.Attentionf("No active sessions found")

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -154,24 +154,25 @@ func SSH(cmd *cobra.Command, args []string) error {
 		isNew = true
 
 	} else {
-
+		var createNewExec bool
 		if execRef == "" {
-			var execs []types.Exec
-
-			execRef, execs, err = selectExec(cmd.Context(), "Select a session to connect to")
+			execRef, createNewExec, err = sessionSelectSSHExecRef(cmd, execRef, false)
 			if err != nil {
 				return err
 			}
-			if len(execs) == 0 {
-				ui.Errorf("❌ No active sessions found and no session name or ID provided. If " +
-					"you want to create a new session, use the --new flag.")
-				os.Exit(1)
-			}
 		}
 
-		execCh, errCh, err = session.Wait(watchCtx, execRef)
-		if err != nil {
-			return err
+		if createNewExec {
+			execCh, errCh, err = execCreateAndWatch(ctx, types.ExecConfig{}, types.GitConfig{})
+			if err != nil {
+				return err
+			}
+			isNew = true
+		} else {
+			execCh, errCh, err = session.Wait(ctx, execRef)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Updates the SSH interface flow to accept creating new resources. Adds a flag specifying parent UX should handle a new resource flow. Resources are created with the default config. Added hints on what to review in the comments.

**Tested**
- SSH Create flow
- Terminate flow 

**Not Tested** 
- VSCode SSH Create Flow.