### PR TITLE
Fix a case where new sessions can't be created with 0 sessions 

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -357,11 +357,6 @@ func sessionSelectSSHExecRef(cmd *cobra.Command, execRef string, allowNew bool) 
 		return "", false, err
 	}
 
-	if len(execs) == 0 {
-		ui.Errorf("❌ No active sessions found and no session name or ID provided. If " +
-			"you want to create a new session, use the --new flag.")
-		os.Exit(1)
-	}
 	return execRef, execRef == newSessionOpt, nil
 }
 


### PR DESCRIPTION
Fix an edge case where 0 sessions prevented the CLI from accessing the Create New Session flow via SSH.