### PR TITLE
[UNW-177] CLI should create SSH config if it does not exist

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -160,7 +160,12 @@ func ensureHosts(e types.Exec) {
 		ui.Debugf("Failed to remove known_hosts entry: %v", err)
 	}
 
-	if err := ssh.AddHost("uw:"+e.ID, e.Connection.Host, e.Connection.User, e.Connection.Port); err != nil {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		ui.Errorf("Failed to get user home directory: %v", err)
+		os.Exit(1)
+	}
+	if err := ssh.AddHost("uw:"+e.ID, e.Connection.Host, e.Connection.User, e.Connection.Port, filepath.Join(homeDir, ".ssh", "config")); err != nil {
 		ui.Debugf("Failed to add host to ssh config: %v", err)
 	}
 }

--- a/ssh/config.go
+++ b/ssh/config.go
@@ -16,7 +16,7 @@ func getUnweaveSSHConfigPath() string {
 	return filepath.Join(config.GetGlobalConfigPath(), "ssh_config")
 }
 
-func AddHost(alias, host, user string, port int) error {
+func AddHost(alias, host, user string, port int, sshConfigPath string) error {
 	configEntry := fmt.Sprintf(`Host %s
     HostName %s
     User %s
@@ -42,12 +42,13 @@ func AddHost(alias, host, user string, port int) error {
 		return err
 	}
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		ui.Errorf("Failed to get user home directory: %v", err)
-		os.Exit(1)
+	// Add an Include directive to the user's ssh config to unweave_global SSH configs - used for vscode-remote.
+	// Create one it if it does not exist.
+	if _, err := os.Stat(sshConfigPath); os.IsNotExist(err) {
+		if _, err = os.Create(sshConfigPath); err != nil {
+			return err
+		}
 	}
-	sshConfigPath := filepath.Join(home, ".ssh", "config")
 
 	lines, err := readLines(sshConfigPath)
 	if err != nil {

--- a/ssh/config.go
+++ b/ssh/config.go
@@ -16,16 +16,16 @@ func getUnweaveSSHConfigPath() string {
 	return filepath.Join(config.GetGlobalConfigPath(), "ssh_config")
 }
 
-var homeDirPath = func() string {
-	path, err := os.UserHomeDir()
+var sshDirPath = func() string {
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		ui.Errorf("Failed to get user home directory: %v", err)
 		os.Exit(1)
 	}
-	return path
+	return filepath.Join(homeDir, ".ssh")
 }()
 
-var sshConfigPath = filepath.Join(homeDirPath, ".ssh", "config")
+var sshConfigPath = filepath.Join(sshDirPath, "config")
 
 func AddHost(alias, host, user string, port int, identityFile string) error {
 	configEntry := fmt.Sprintf(`Host %s
@@ -55,7 +55,7 @@ func AddHost(alias, host, user string, port int, identityFile string) error {
 	}
 
 	// Add an Include directive to the user's ssh config to unweave_global SSH configs - used for vscode-remote:
-	err = os.MkdirAll(filepath.Join(homeDirPath, ".ssh"), 0700)
+	err = os.MkdirAll(sshDirPath, 0700)
 	if err != nil {
 		fmt.Println("Failed to create .ssh folder:", err)
 	}

--- a/ssh/config_test.go
+++ b/ssh/config_test.go
@@ -1,0 +1,44 @@
+package ssh
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/franela/goblin"
+)
+
+func TestAddHost(t *testing.T) {
+	g := Goblin(t)
+
+	g.Describe("AddHost", func() {
+		homeDir, _ := os.UserHomeDir()
+		sshConfigPath := filepath.Join(homeDir, ".ssh", "test_config")
+		unweaveConfigPath := getUnweaveSSHConfigPath()
+
+		g.BeforeEach(func() {
+			// Remove any existing config files
+			os.Remove(sshConfigPath)
+		})
+
+		g.AfterEach(func() {
+			// Remove the created config files
+			os.Remove(sshConfigPath)
+		})
+
+		g.It("should add the Include directive to the .ssh/config file", func() {
+			err := AddHost("example", "example.com", "user", 22, sshConfigPath)
+			g.Assert(err).Equal(nil)
+
+			configData, err := ioutil.ReadFile(sshConfigPath)
+			g.Assert(err).Equal(nil)
+
+			configContent := string(configData)
+			expectedInclude := "Include " + unweaveConfigPath
+
+			g.Assert(strings.Contains(configContent, expectedInclude)).Equal(true)
+		})
+	})
+}

--- a/ssh/config_test.go
+++ b/ssh/config_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/franela/goblin"
 )
 
-func TestAddHost(t *testing.T) {
+func TestConfig(t *testing.T) {
 	g := Goblin(t)
 
 	g.Describe("AddHost", func() {

--- a/ssh/config_test.go
+++ b/ssh/config_test.go
@@ -14,7 +14,7 @@ func TestConfig(t *testing.T) {
 	g := Goblin(t)
 
 	g.Describe("AddHost", func() {
-		testCfgPath := filepath.Join(homeDirPath, ".ssh", "test_config")
+		testCfgPath := filepath.Join(sshDirPath, "test_config")
 		unweaveConfigPath := getUnweaveSSHConfigPath()
 
 		g.BeforeEach(func() {


### PR DESCRIPTION
This PR addresses a bug where the `AddHost` function does not ensure the presence of the `.ssh/config` file before adding the `Include` directive. Preventing the proper configuration of SSH hosts may prevent VSCode remote from connecting to a new session (or other IDEs which depend on it).

Fixed by adding a check for the existence of the `.ssh/config` file and creating it if it doesn't exist before adding the `Include` directive. Adds a test to sanity check, and parameterized the input directory of the `ssh/.config` file to make the behavior testable.