### PR TITLE
[UNW-176] Ensure Root logs into the Source dir (SSH)

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -265,7 +265,7 @@ func copySourceUnTar(srcPath, dstPath string, connectionInfo types.ConnectionInf
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-i", prvKeyPath,
 		fmt.Sprintf("%s@%s", connectionInfo.User, connectionInfo.Host),
-		// ensure root logs into the source dir
+		// ensure dstPath exist and root logs into that path
 		fmt.Sprintf("mkdir -p %s && echo 'cd %s' > /root/.bashrc &&", dstPath, dstPath),
 		fmt.Sprintf("tar -xzf %s -C %s && rm -rf %s", srcPath, dstPath, srcPath),
 	)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -168,13 +168,14 @@ func ensureHosts(e types.Exec) {
 func handleCopySourceDir(isNew bool, e types.Exec, privKey string) error {
 	// TODO: Wait until port is open before cleaning up the source code
 
+	const dstPath = "/home/unweave"
 	if !config.NoCopySource && isNew {
 		dir, err := config.GetActiveProjectPath()
 		if err != nil {
 			ui.Errorf("Failed to get active project path. Skipping copying source directory")
 			return fmt.Errorf("failed to get active project path: %v", err)
 		}
-		if err := copySource(e.ID, dir, "/home/ubuntu", *e.Connection, privKey); err != nil {
+		if err := copySource(e.ID, dir, dstPath, *e.Connection, privKey); err != nil {
 			fmt.Println(err)
 		}
 	} else {
@@ -264,6 +265,8 @@ func copySourceUnTar(srcPath, dstPath string, connectionInfo types.ConnectionInf
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-i", prvKeyPath,
 		fmt.Sprintf("%s@%s", connectionInfo.User, connectionInfo.Host),
+		// ensure root logs into the source dir
+		fmt.Sprintf("mkdir -p %s && echo 'cd %s' > /root/.bashrc &&", dstPath, dstPath),
 		fmt.Sprintf("tar -xzf %s -C %s && rm -rf %s", srcPath, dstPath, srcPath),
 	)
 


### PR DESCRIPTION
Unweave user's SSH using Root, after testing various methods the only way this seems to work is by appending the .bashrc file. The natural place to do this seems to be when copying source. 

Tried both using the LocalCommand SSH config and RemoteCommand SSH config directives to no avail. Instead of looking around SSH found its simpler to do what I'd probably do if setting up on my home machine :stuck_out_tongue: 

This PR adds support for logging in as root to where the source files were extracted by appending a 'cd' to the root `.bashrc` file.

**Before Merge / Future Work**
- We need to run a quick test that this works with VSCode once related PRs are merged in, if not will have to investigate that as a separate issue. Currently master is broken so we can't run an E2E.
-