### PR TITLE
Ensure getDefaultKey always returns a valid key

### DIFF
--- a/cmd/code.go
+++ b/cmd/code.go
@@ -32,7 +32,7 @@ func Code(cmd *cobra.Command, args []string) error {
 					os.Exit(1)
 				}
 				if err != nil {
-					ui.Errorf("failed to get private key: %s", err)
+					ui.Errorf("Failed to get private key: %s", err)
 					os.Exit(1)
 				}
 

--- a/cmd/code.go
+++ b/cmd/code.go
@@ -28,7 +28,7 @@ func Code(cmd *cobra.Command, args []string) error {
 			if e.Status == types.StatusRunning {
 				prvKey, err := getDefaultKey(ctx, e, prvKey)
 				if prvKey == "" {
-					ui.Errorf("expected private key to be none empty string")
+					ui.Errorf("Expected private key to be none empty string")
 					os.Exit(1)
 				}
 				if err != nil {

--- a/cmd/code.go
+++ b/cmd/code.go
@@ -26,10 +26,18 @@ func Code(cmd *cobra.Command, args []string) error {
 		select {
 		case e := <-execCh:
 			if e.Status == types.StatusRunning {
-				prvKey := getDefaultKey(ctx, e, prvKey)
-				ensureHosts(e, prvKey)
+				prvKey, err := getDefaultKey(ctx, e, prvKey)
+				if prvKey == "" {
+					ui.Errorf("expected private key to be none empty string")
+					os.Exit(1)
+				}
+				if err != nil {
+					ui.Errorf("failed to get private key: %s", err)
+					os.Exit(1)
+				}
 
-				err := handleCopySourceDir(isNew, e, prvKey)
+				ensureHosts(e, prvKey)
+				err = handleCopySourceDir(isNew, e, prvKey)
 				if err != nil {
 					return err
 				}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -54,11 +54,11 @@ func SSH(cmd *cobra.Command, args []string) error {
 				defer cleanupHosts(e)
 				prvKey, err := getDefaultKey(ctx, e, prvKey)
 				if prvKey == "" {
-					ui.Errorf("expected private key to be none empty string")
+					ui.Errorf("Expected private key to be none empty string")
 					os.Exit(1)
 				}
 				if err != nil {
-					ui.Errorf("failed to get private key: %s", err)
+					ui.Errorf("Failed to get private key: %s", err)
 					os.Exit(1)
 				}
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -296,25 +296,37 @@ func copySourceUnTar(srcPath, dstPath string, connectionInfo types.ConnectionInf
 
 // getDefaultKey tries to find the private key for this Exec, or relies on
 // a default key if it can't be found
-func getDefaultKey(ctx context.Context, e types.Exec, defaultKey string) string {
-	keysFolder := config.GetUnweaveSSHKeysFolder()
-
-	// Case where we know what the public key was when the session was created
-	dirEntries, err := os.ReadDir(keysFolder)
-	if err != nil {
-		ui.HandleError(err)
-		os.Exit(1)
+func getDefaultKey(ctx context.Context, e types.Exec, defaultKey string) (string, error) {
+	// if the user has specified their own private key location
+	if defaultKey != "" {
+		return defaultKey, nil
 	}
 
-	list := filterPublicKeys(dirEntries)
-	for _, key := range list {
-		// Unweave private keys are represented by the public key name
+	keysFolder := config.GetUnweaveSSHKeysFolder()
+	dirEntries, err := os.ReadDir(keysFolder)
+	if err != nil {
+		return "", fmt.Errorf("failed to read SSH keys folder: %w", err)
+	}
+
+	publicKeys := filterPublicKeys(dirEntries)
+
+	// Ensure default key is never ""
+	// Unweave private keys are trimmed public ones
+	for _, key := range publicKeys {
 		name := strings.TrimSuffix(key.Name(), ".pub")
+		defaultKey = filepath.Join(keysFolder, name)
 		if e.SSHKey.Name == name {
-			privateKeyPath := filepath.Join(keysFolder, name)
-			return privateKeyPath
+			return defaultKey, nil
 		}
 	}
 
-	return defaultKey
+	if defaultKey == "" {
+		privKeyPath, _, err := generateSSHKey(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate SSH key: %w", err)
+		}
+		return privKeyPath, nil
+	}
+
+	return defaultKey, nil
 }

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -52,10 +52,18 @@ func SSH(cmd *cobra.Command, args []string) error {
 		case e := <-execCh:
 			if e.Status == types.StatusRunning {
 				defer cleanupHosts(e)
-				prvKey := getDefaultKey(ctx, e, prvKey)
-				ensureHosts(e, prvKey)
+				prvKey, err := getDefaultKey(ctx, e, prvKey)
+				if prvKey == "" {
+					ui.Errorf("expected private key to be none empty string")
+					os.Exit(1)
+				}
+				if err != nil {
+					ui.Errorf("failed to get private key: %s", err)
+					os.Exit(1)
+				}
 
-				err := handleCopySourceDir(isNew, e, prvKey)
+				ensureHosts(e, prvKey)
+				err = handleCopySourceDir(isNew, e, prvKey)
 				if err != nil {
 					return err
 				}

--- a/ssh/config.go
+++ b/ssh/config.go
@@ -38,6 +38,9 @@ func AddHost(alias, host, user string, port int, identityFile string) error {
     ForwardAgent yes
     IdentityFile %s
 `, host, host, user, port, identityFile)
+	if identityFile == "" {
+		return fmt.Errorf("expected identity file, got an empty string")
+	}
 
 	file, err := os.OpenFile(getUnweaveSSHConfigPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {


### PR DESCRIPTION
Currently, the getDefaultKey method may return an empty string if no user key is specified. Really what we want is to prefer a specified user key _and_ ensure that there is always some kind of key available for an instance, even if it means generating a new one. This way, even if a user ends up in a peculiar state where they attempt to SSH with an invalid key (due to tampering with the unweave managed/global keystore), they will at least receive a meaningful "bad public key" error in SSH.

This PR:

- Updates the getDefaultKey method to consistently return a key, even if it needs to generate a new one.
- Adds an assertion to and prior to calling the AddHosts function, which generates new or missing SSH configs, to guarantee that a private key passed to it is never an empty string. 

**Bugfixes**
- Fixes a case where trying to use the CLI results in `no argument after keyword "identityfile"` . If you're still getting the error you will need to go to `~/.unweave_global/ssh_config` and manually delete all the SSH configs with no argument after the identity file keyword or just delete the whole file. SSH config really cares about whether it can parse the file at all