### PR TITLE
DRY SCP Command, add Copy command

### DIFF
--- a/cmd/code.go
+++ b/cmd/code.go
@@ -39,7 +39,8 @@ func Code(cmd *cobra.Command, args []string) error {
 				ensureHosts(e, prvKey)
 				err = handleCopySourceDir(isNew, e, prvKey)
 				if err != nil {
-					return err
+					ui.HandleError(err)
+					os.Exit(1)
 				}
 
 				ui.Infof("🔧 Setting up VS Code ...")

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -43,6 +44,9 @@ func Copy(cmd *cobra.Command, args []string) error {
 
 		scpArgs = append(scpArgs, formattedArg)
 	}
+	if targetExec == nil {
+		return fmt.Errorf("At least one remote host must be specified")
+	}
 
 	if targetExec.SSHKey.PublicKey == nil && config.SSHPublicKeyPath == "" {
 		return fmt.Errorf("Failed to identify public key, check your Unweave config file or specify it manually")
@@ -63,6 +67,10 @@ func Copy(cmd *cobra.Command, args []string) error {
 
 func formatCopyArgToScpArgs(ctx context.Context, argExecID string, exec *types.Exec, arg string) (string, error) {
 	if argExecID == "" {
+		if arg == "." {
+			return os.Getwd()
+		}
+
 		return arg, nil
 	}
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/unweave/cli/config"
+	"github.com/unweave/cli/ui"
+	"github.com/unweave/unweave/api/types"
+)
+
+var getSessionIDRegex = regexp.MustCompile(`^sess:([^/]+)`)
+
+func Copy(cmd *cobra.Command, args []string) error {
+	scpArgs := make([]string, 0, len(args))
+	var targetExec *types.Exec
+
+	for _, arg := range args {
+		argExecID, err := getExecIDFromCopyArgs(arg)
+		if err != nil {
+			return err
+		}
+
+		if argExecID != "" && targetExec != nil {
+			return fmt.Errorf("Copying between multiple sessions is not supported")
+		}
+
+		if argExecID != "" {
+			targetExec, err = getExecByNameOrID(cmd.Context(), argExecID)
+			if err != nil {
+				return fmt.Errorf("Could not find session by name or ID")
+			}
+		}
+
+		formattedArg, err := formatCopyArgToScpArgs(cmd.Context(), argExecID, targetExec, arg)
+		if err != nil {
+			return err
+		}
+
+		scpArgs = append(scpArgs, formattedArg)
+	}
+
+	if targetExec.SSHKey.PublicKey == nil && config.SSHPublicKeyPath == "" {
+		return fmt.Errorf("Failed to identify public key, check your Unweave config file or specify it manually")
+	}
+
+	publicKeyPath := ""
+	if config.SSHPrivateKeyPath != "" {
+		publicKeyPath = config.SSHPublicKeyPath
+	} else {
+		publicKeyPath = *targetExec.SSHKey.PublicKey
+	}
+
+	ui.Infof(fmt.Sprintf("🔄 Copying %s to %s", scpArgs[0], scpArgs[1]))
+	err := copySourceSCP(scpArgs, publicKeyPath)
+	ui.Infof("✅  Copied %s to %s", scpArgs[0], scpArgs[1])
+	return err
+}
+
+func formatCopyArgToScpArgs(ctx context.Context, argExecID string, exec *types.Exec, arg string) (string, error) {
+	if argExecID == "" {
+		return arg, nil
+	}
+
+	if exec == nil {
+		return "", fmt.Errorf("Assertion failed, please file an issue with the Unweave team." +
+			"Please provide steps to reproduce")
+	}
+
+	connectionInfo := exec.Connection
+	if connectionInfo == nil {
+		return "", fmt.Errorf("Could not get connection from session")
+	}
+
+	parts := strings.SplitN(arg, "/", 2)
+	dir := filepath.Clean(parts[1])
+
+	return fmt.Sprintf("%s@%s:/%s", connectionInfo.User, connectionInfo.Host, dir), nil
+}
+
+func getExecIDFromCopyArgs(input string) (string, error) {
+	matches := getSessionIDRegex.FindStringSubmatch(input)
+
+	if len(matches) == 2 {
+		return matches[1], nil
+	} else if input == "sess:" {
+		return "", fmt.Errorf("ExecId not specified")
+	} else {
+		return "", nil
+	}
+}

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -23,7 +23,8 @@ func Copy(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		argExecID, err := getExecIDFromCopyArgs(arg)
 		if err != nil {
-			return err
+			ui.HandleError(err)
+			os.Exit(1)
 		}
 
 		if argExecID != "" && targetExec != nil {
@@ -39,7 +40,8 @@ func Copy(cmd *cobra.Command, args []string) error {
 
 		formattedArg, err := formatCopyArgToScpArgs(cmd.Context(), argExecID, targetExec, arg)
 		if err != nil {
-			return err
+			ui.HandleError(err)
+			os.Exit(1)
 		}
 
 		scpArgs = append(scpArgs, formattedArg)

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -56,7 +56,7 @@ func Copy(cmd *cobra.Command, args []string) error {
 	}
 
 	ui.Infof(fmt.Sprintf("🔄 Copying %s to %s", scpArgs[0], scpArgs[1]))
-	err := copySourceSCP(scpArgs, publicKeyPath)
+	err := copySourceSCP(scpArgs[0], scpArgs[1], publicKeyPath)
 	ui.Infof("✅  Copied %s to %s", scpArgs[0], scpArgs[1])
 	return err
 }

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -55,9 +55,9 @@ func Copy(cmd *cobra.Command, args []string) error {
 		publicKeyPath = *targetExec.SSHKey.PublicKey
 	}
 
-	ui.Infof(fmt.Sprintf("🔄 Copying %s to %s", scpArgs[0], scpArgs[1]))
+	ui.Infof(fmt.Sprintf("🔄 Copying %s => %s", scpArgs[0], scpArgs[1]))
 	err := copySourceSCP(scpArgs[0], scpArgs[1], publicKeyPath)
-	ui.Infof("✅  Copied %s to %s", scpArgs[0], scpArgs[1])
+	ui.Infof("✅  Copied %s => %s", scpArgs[0], scpArgs[1])
 	return err
 }
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -207,8 +207,8 @@ func copySourceAndUnzip(execID, rootDir, dstPath string, connectionInfo types.Co
 	ui.Infof("🔄 Copying source to %q", dstPath)
 
 	// target to copy to i.e. /home/user/Desktop/ user@your.server.example.com:/path/to/foo
-	sourceTarget := fmt.Sprintf("%s@%s:%s", connectionInfo.User, connectionInfo.Host, tmpDstPath)
-	if err := copySourceSCP([]string{tmpFile.Name(), sourceTarget}, privKeyPath); err != nil {
+	remoteTarget := fmt.Sprintf("%s@%s:%s", connectionInfo.User, connectionInfo.Host, tmpDstPath)
+	if err := copySourceSCP(tmpFile.Name(), remoteTarget, privKeyPath); err != nil {
 		return fmt.Errorf("failed to copy source: %w", err)
 	}
 
@@ -230,7 +230,7 @@ func createTempContextFile(execID string) (*os.File, error) {
 	return tmpFile, nil
 }
 
-func copySourceSCP(fromTo []string, privKeyPath string) error {
+func copySourceSCP(from, to string, privKeyPath string) error {
 	scpCommandArgs := []string{
 		"-r",
 		"-o", "StrictHostKeyChecking=no",
@@ -240,7 +240,7 @@ func copySourceSCP(fromTo []string, privKeyPath string) error {
 		scpCommandArgs = append(scpCommandArgs, "-i", privKeyPath)
 	}
 
-	scpCommandArgs = append(scpCommandArgs, fromTo...)
+	scpCommandArgs = append(scpCommandArgs, []string{from, to}...)
 
 	scpCommand := exec.Command("scp", scpCommandArgs...)
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -65,7 +65,8 @@ func SSH(cmd *cobra.Command, args []string) error {
 				ensureHosts(e, prvKey)
 				err = handleCopySourceDir(isNew, e, prvKey)
 				if err != nil {
-					return err
+					ui.HandleError(err)
+					os.Exit(1)
 				}
 
 				if err := ssh.Connect(ctx, *e.Connection, prvKey, sshArgs); err != nil {
@@ -183,7 +184,7 @@ func handleCopySourceDir(isNew bool, e types.Exec, privKey string) error {
 			return fmt.Errorf("failed to get active project path: %v", err)
 		}
 		if err := copySourceAndUnzip(e.ID, dir, config.ProjectHostDir(), *e.Connection, privKey); err != nil {
-			fmt.Println(err)
+			return err
 		}
 	} else {
 		ui.Infof("Skipping copying source directory")

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -183,7 +183,7 @@ func handleCopySourceDir(isNew bool, e types.Exec, privKey string) error {
 			ui.Errorf("Failed to get active project path. Skipping copying source directory")
 			return fmt.Errorf("failed to get active project path: %v", err)
 		}
-		if err := copySource(e.ID, dir, dstPath, *e.Connection, privKey); err != nil {
+		if err := copySourceAndUnzip(e.ID, dir, dstPath, *e.Connection, privKey); err != nil {
 			fmt.Println(err)
 		}
 	} else {
@@ -192,7 +192,7 @@ func handleCopySourceDir(isNew bool, e types.Exec, privKey string) error {
 	return nil
 }
 
-func copySource(execID, rootDir, dstPath string, connectionInfo types.ConnectionInfo, privKeyPath string) error {
+func copySourceAndUnzip(execID, rootDir, dstPath string, connectionInfo types.ConnectionInfo, privKeyPath string) error {
 	ui.Infof("🧳 Gathering context from %q", rootDir)
 
 	tmpFile, err := createTempContextFile(execID)
@@ -205,7 +205,11 @@ func copySource(execID, rootDir, dstPath string, connectionInfo types.Connection
 
 	tmpDstPath := filepath.Join("/tmp", fmt.Sprintf("uw-context-%s.tar.gz", execID))
 
-	if err := copySourceSCP(tmpFile.Name(), tmpDstPath, dstPath, connectionInfo, privKeyPath); err != nil {
+	ui.Infof("🔄 Copying source to %q", dstPath)
+
+	// target to copy to i.e. /home/user/Desktop/ user@your.server.example.com:/path/to/foo
+	sourceTarget := fmt.Sprintf("%s@%s:%s", connectionInfo.User, connectionInfo.Host, tmpDstPath)
+	if err := copySourceSCP([]string{tmpFile.Name(), sourceTarget}, privKeyPath); err != nil {
 		return fmt.Errorf("failed to copy source: %w", err)
 	}
 
@@ -227,7 +231,7 @@ func createTempContextFile(execID string) (*os.File, error) {
 	return tmpFile, nil
 }
 
-func copySourceSCP(srcPath, tmpDstPath, dstPath string, connectionInfo types.ConnectionInfo, privKeyPath string) error {
+func copySourceSCP(fromTo []string, privKeyPath string) error {
 	scpCommandArgs := []string{
 		"-r",
 		"-o", "StrictHostKeyChecking=no",
@@ -236,7 +240,8 @@ func copySourceSCP(srcPath, tmpDstPath, dstPath string, connectionInfo types.Con
 	if privKeyPath != "" {
 		scpCommandArgs = append(scpCommandArgs, "-i", privKeyPath)
 	}
-	scpCommandArgs = append(scpCommandArgs, srcPath, fmt.Sprintf("%s@%s:%s", connectionInfo.User, connectionInfo.Host, tmpDstPath))
+
+	scpCommandArgs = append(scpCommandArgs, fromTo...)
 
 	scpCommand := exec.Command("scp", scpCommandArgs...)
 
@@ -245,8 +250,6 @@ func copySourceSCP(srcPath, tmpDstPath, dstPath string, connectionInfo types.Con
 
 	scpCommand.Stdout = stdout
 	scpCommand.Stderr = stderr
-
-	ui.Infof("🔄 Copying source to %q", dstPath)
 
 	if err := scpCommand.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {

--- a/main.go
+++ b/main.go
@@ -148,7 +148,6 @@ func init() {
 		Use:   "cp <source-path> <destination-path>",
 		Short: "Copy files and folders to or from a remote host",
 		Long: wordwrap.String("Copy files and folders to or from a remote host \n\n"+
-			"cp <source-path> <destination-path>\n\n"+
 			"To copy to a remote session, you must prefix the remote path with the session "+
 			"name `sess:<session-name>`. The `sess:` prefix is necessary.\n\n"+
 			"The full syntax for this command is:\n\n"+

--- a/main.go
+++ b/main.go
@@ -145,11 +145,24 @@ func init() {
 	rootCmd.AddCommand(codeCmd)
 
 	cpCmd := &cobra.Command{
-		Use:     "cp",
-		Short:   "Copy files and folders to or from a remote host, use . for current directory",
-		Long:    "Example: unweave cp . sess:<exec-name/id>/absolute/path/on/remote",
+		Use:   "cp <source-path> <destination-path>",
+		Short: "Copy files and folders to or from a remote host",
+		Long: wordwrap.String("Copy files and folders to or from a remote host \n\n"+
+			"cp <source-path> <destination-path>\n\n"+
+			"To copy to a remote session, you must prefix the remote path with the session "+
+			"name `sess:<session-name>`. The `sess:` prefix is necessary.\n\n"+
+			"The full syntax for this command is:\n\n"+
+			"Local to remote:\n"+
+			"unweave cp <local-path> sess:<session-name><remote-path>\n\n"+
+			"Remote to local:\n"+
+			"unweave cp sess:<session-name><remote-path> <local-path> \n\n"+
+			"Current directory to remote:\n"+
+			"unweave cp . sess:<session-name><remote-path>\n\n"+
+			"Example: \n"+
+			"\tunweave cp /home/data sess:session-name/home/ml-data\n"+
+			"\tunweave cp sess:session-name/home/ml-data /home/data\n", ui.MaxOutputLineLength),
 		Args:    cobra.ExactArgs(2),
-		Aliases: []string{"copy"},
+		Aliases: []string{"cp", "copy"},
 		GroupID: groupDev,
 		RunE:    withValidProjectURI(cmd.Copy),
 	}

--- a/main.go
+++ b/main.go
@@ -146,8 +146,8 @@ func init() {
 
 	cpCmd := &cobra.Command{
 		Use:     "cp",
-		Short:   "Copy files and folders to or from a remote host",
-		Long:    "Example: unweave cp local/path sess:<exec-name/id>/absolute/path/on/remote",
+		Short:   "Copy files and folders to or from a remote host, use . for current directory",
+		Long:    "Example: unweave cp . sess:<exec-name/id>/absolute/path/on/remote",
 		Args:    cobra.ExactArgs(2),
 		Aliases: []string{"copy"},
 		GroupID: groupDev,

--- a/main.go
+++ b/main.go
@@ -144,6 +144,17 @@ func init() {
 	codeCmd.Flags().IntVar(&config.HDD, "hdd", 0, "Amount of hard-disk space to allocate in GB")
 	rootCmd.AddCommand(codeCmd)
 
+	cpCmd := &cobra.Command{
+		Use:     "cp",
+		Short:   "Copy files and folders to or from a remote host",
+		Long:    "Example: unweave cp local/path sess:<exec-name/id>/absolute/path/on/remote",
+		Args:    cobra.ExactArgs(2),
+		Aliases: []string{"copy"},
+		GroupID: groupDev,
+		RunE:    withValidProjectURI(cmd.Copy),
+	}
+	rootCmd.AddCommand(cpCmd)
+
 	rootCmd.AddCommand(&cobra.Command{
 		Use:     "config",
 		Short:   "Show the current config",

--- a/ui/constants.go
+++ b/ui/constants.go
@@ -1,6 +1,6 @@
 package ui
 
 const (
-	MaxOutputLineLength = 100
+	MaxOutputLineLength = 80
 	IndentWidth         = 2
 )


### PR DESCRIPTION
This pull request (PR) adds the Copy command to the Unweave CLI. The approach is to reuse the existing CopySource function but modify it slightly to make it more versatile, which prevents a large diff.

Before merging, we may want to consider adding some quality-of-life (QoL) improvements such as:
-  Introducing specialized wildcards, like using . to specify the current directory and all its contents.
-  Implementing safeguards to ignore SCP to dangerous paths, such as /, /etc, /var, or /user, on the remote or host.
-   Adding an "in progress" indicator for large copies since copying the entire CLI directory can take time.
-   Automatically creating the destination directory if it does not exist on the remote.


Example flow:  

1. go run . copy /home/mmacheerpuppy/foobar sess:moon-tears-brass-met/home/
2. Make changes to foobar
3. go run . copy sess:moon-tears-brass-met/home/foobar /home/mmacheerpuppy/barfoo
