### PR TITLE
Fix a case where the GPU types from config could be nil

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -5,3 +5,5 @@ const (
 	ProjectConfigDirName = ".unweave"
 	UnweaveSSHKeysDir    = ".unweave_global/.ssh"
 )
+
+var DefaultGPUTypes = []string{""}

--- a/session/session.go
+++ b/session/session.go
@@ -56,13 +56,10 @@ func createSession(ctx context.Context, params types.ExecCreateParams, gpuType s
 }
 
 func createSessionFromConfigGPUTypes(ctx context.Context, params types.ExecCreateParams) (*types.Exec, error) {
-	gpuTypesFromConfig, err := gpuTypesFromConfig()
-	if err != nil {
-		ui.Errorf(err.Error())
-		os.Exit(1)
-	}
+	gpuTypesFromConfig := gpuTypesFromConfig()
 
 	var exec *types.Exec
+	var err error
 	for _, gpuType := range gpuTypesFromConfig {
 		exec, err = createSession(ctx, params, gpuType)
 		if err != nil {
@@ -87,7 +84,7 @@ func isOutOfCapacityError(err error) bool {
 }
 
 // gpuTypesFromConfig returns the GPU types in config.toml or a set of defaults, never nil
-func gpuTypesFromConfig() ([]string, error) {
+func gpuTypesFromConfig() []string {
 	var gpuTypeIDs []string
 	provider := config.Config.Project.DefaultProvider
 	if config.Provider != "" {
@@ -100,10 +97,11 @@ func gpuTypesFromConfig() ([]string, error) {
 		gpuTypeIDs = config.DefaultGPUTypes
 	}
 	if len(gpuTypeIDs) == 0 {
-		return nil, fmt.Errorf("GPU type config should be provided or default, never nil")
+		ui.HandleError(fmt.Errorf("❌ Please specify default GPU types in .unweave/config.toml and try again"))
+		os.Exit(1)
 	}
 
-	return gpuTypeIDs, nil
+	return gpuTypeIDs
 }
 
 func renderSessionCreated(exec *types.Exec) {


### PR DESCRIPTION
This PR fixes a case where GPU types from config was an empty list of .unweave/config.toml did not contain any GPUs in `node_types `, by introducing an empty string as the static default for the CLI to go by. API call result:

- Resolves UNW-187

![image](https://github.com/unweave/cli/assets/8885269/bbc0ad0a-2a17-46fe-9511-585a7f6f2743)
