### PR TITLE
Implement remote to local directory copying + Bugfixes

### DIFF
--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -16,10 +16,6 @@ import (
 var getSessionIDRegex = regexp.MustCompile(`^sess:([^/]+)`)
 
 func Copy(cmd *cobra.Command, args []string) error {
-	if len(args) < 2 {
-		return fmt.Errorf("At least two path arguments are required for the Copy command")
-	}
-
 	exec, err := getTargetExec(cmd, args)
 	if err != nil {
 		return err

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -46,10 +46,10 @@ func Copy(cmd *cobra.Command, args []string) error {
 	}
 
 	switch {
-	case shouldCopyLocalDirToRemote(args[0], args[1]):
+	case shouldCopyLocalDirToRemote(args[0]):
 		// Eventually simplify this to talk in terms of scpArgs, too many dependants for now
 		err = copyDirFromLocalAndUnzip(exec.ID, scpArgs[0], splitSessFromDirpath(args[1]), *exec.Connection, privateKey)
-	case shouldCopyRemoteDirToLocal(args[0], args[1]):
+	case shouldCopyRemoteDirToLocal(args[0]):
 		err = copyDirFromRemoteAndUnzip(scpArgs[0], scpArgs[1], privateKey)
 	default:
 		err = copySourceSCP(scpArgs[0], scpArgs[1], privateKey)
@@ -65,12 +65,12 @@ func Copy(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func shouldCopyLocalDirToRemote(localPath1, remotePath2 string) bool {
-	if strings.Contains(localPath1, "sess:") {
+func shouldCopyLocalDirToRemote(localPath string) bool {
+	if strings.Contains(localPath, "sess:") {
 		return false
 	}
 
-	pathInfo, err := os.Stat(localPath1)
+	pathInfo, err := os.Stat(localPath)
 	if err != nil || pathInfo == nil {
 		return false
 	}
@@ -78,12 +78,12 @@ func shouldCopyLocalDirToRemote(localPath1, remotePath2 string) bool {
 	return pathInfo.IsDir()
 }
 
-func shouldCopyRemoteDirToLocal(remotePath1, localPath2 string) bool {
-	if !strings.Contains(remotePath1, "sess:") {
+func shouldCopyRemoteDirToLocal(remotePath string) bool {
+	if !strings.Contains(remotePath, "sess:") {
 		return false
 	}
 
-	sessFromDirpath := splitSessFromDirpath(remotePath1)
+	sessFromDirpath := splitSessFromDirpath(remotePath)
 	return regExValidDirpath.MatchString(sessFromDirpath)
 }
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -13,7 +13,10 @@ import (
 	"github.com/unweave/unweave/api/types"
 )
 
-var getSessionIDRegex = regexp.MustCompile(`^sess:([^/]+)`)
+var (
+	getSessionIDRegex = regexp.MustCompile(`^sess:([^/]+)`)
+	regExValidDirpath = regexp.MustCompile(`^\/(?:[^\/]+\/)*[^\/]+$`)
+)
 
 func Copy(cmd *cobra.Command, args []string) error {
 	exec, err := getTargetExec(cmd, args)
@@ -81,13 +84,7 @@ func shouldCopyRemoteDirToLocal(remotePath1, localPath2 string) bool {
 	}
 
 	sessFromDirpath := splitSessFromDirpath(remotePath1)
-	return isValidDirPath(sessFromDirpath)
-}
-
-var regExValidDirpath = regexp.MustCompile(`^\/(?:[^\/]+\/)*[^\/]+$`)
-
-func isValidDirPath(path string) bool {
-	return regExValidDirpath.MatchString(path)
+	return regExValidDirpath.MatchString(sessFromDirpath)
 }
 
 func getTargetExec(cmd *cobra.Command, args []string) (*types.Exec, error) {

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -65,12 +65,12 @@ func Copy(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func shouldCopyLocalDirToRemote(localPath string) bool {
-	if strings.Contains(localPath, "sess:") {
+func shouldCopyLocalDirToRemote(from string) bool {
+	if strings.Contains(from, "sess:") {
 		return false
 	}
 
-	pathInfo, err := os.Stat(localPath)
+	pathInfo, err := os.Stat(from)
 	if err != nil || pathInfo == nil {
 		return false
 	}
@@ -78,12 +78,12 @@ func shouldCopyLocalDirToRemote(localPath string) bool {
 	return pathInfo.IsDir()
 }
 
-func shouldCopyRemoteDirToLocal(remotePath string) bool {
-	if !strings.Contains(remotePath, "sess:") {
+func shouldCopyRemoteDirToLocal(from string) bool {
+	if !strings.Contains(from, "sess:") {
 		return false
 	}
 
-	sessFromDirpath := splitSessFromDirpath(remotePath)
+	sessFromDirpath := splitSessFromDirpath(from)
 	return regExValidDirpath.MatchString(sessFromDirpath)
 }
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -222,6 +222,90 @@ func copySourceAndUnzip(execID, rootDir, dstPath string, connectionInfo types.Co
 	return nil
 }
 
+func copyDirFromRemoteAndUnzip(sshTarget, localDirectory, privateKey string) error {
+	ui.Infof("🧳 Gathering context from %q", sshTarget)
+
+	remotePath, err := zipRemoteDirectory(sshTarget, privateKey)
+	if err != nil {
+		return fmt.Errorf("Failed to zip the remote directory. Expected both a remote target and directory in %s", sshTarget)
+	}
+
+	ui.Infof("📦 Copying the archive of the remote path to the host...")
+
+	sshTargetAndDir := strings.Split(sshTarget, ":")
+	if len(sshTargetAndDir) != 2 {
+		return fmt.Errorf("Expected target to be in the format 'user@host:directory'")
+	}
+	sshTargetDirectory := sshTargetAndDir[0] + ":" + remotePath
+	remoteFilename := filepath.Base(remotePath)
+	archiveLocalTargetDir := config.GetGlobalConfigPath()
+	archiveLocalTarget := filepath.Join(archiveLocalTargetDir, remoteFilename)
+
+	err = copySourceSCP(sshTargetDirectory, config.GetGlobalConfigPath(), privateKey)
+	if err != nil {
+		return fmt.Errorf("Failed to copy the archive of your remote path to the host. "+
+			"Please check if %s exists on the remote and ensure Unweave has the necessary permissions to access %s",
+			sshTargetDirectory, archiveLocalTargetDir)
+	}
+
+	ui.Infof("🗜️ Unzipping the copied archive to the local directory...")
+
+	cmd := exec.Command("tar", "-xf", archiveLocalTarget, "-C", localDirectory, "--strip-components=1")
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to unzip the copied archive of your code from %s to %s. "+
+			"Please ensure that Unweave has the necessary permissions to access %s and perform this operation manually",
+			archiveLocalTarget, localDirectory, archiveLocalTarget)
+	}
+
+	return nil
+}
+
+// zipRemoteDirectory takes an ssh target, and zips up the contents of that target to a returned in the remote /tmp
+func zipRemoteDirectory(sshTarget, privateKeyPath string) (string, error) {
+	sshTargetAndDir := strings.Split(sshTarget, ":")
+	if len(sshTargetAndDir) != 2 {
+		return "", fmt.Errorf("Failed to zip remote directory, expected both a remote target and directory in %s", sshTarget)
+	}
+
+	timestamp := time.Now().Unix()
+	outputFileName := fmt.Sprintf("/tmp/uw-context-%d.tar.gz", timestamp)
+	tarCmd := fmt.Sprintf("tar -czf %s -C %s .", outputFileName, sshTargetAndDir[1])
+
+	sshCommand := exec.Command(
+		"ssh",
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "UserKnownHostsFile=/dev/null",
+		"-i", privateKeyPath,
+		sshTargetAndDir[0],
+		tarCmd,
+	)
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	sshCommand.Stdout = stdout
+	sshCommand.Stderr = stderr
+
+	if err := sshCommand.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			// Exited with non-zero exit code
+			if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				if status.ExitStatus() == 255 {
+					ui.Infof("The remote host closed the connection.")
+					return "", fmt.Errorf("failed to copy source: %w", err)
+				}
+			}
+			ui.Infof("Failed to extract source directory on remote host: %s", stderr.String())
+			return "", err
+		}
+		return "", fmt.Errorf("failed to unzip on remote host: %v", err)
+	}
+
+	return outputFileName, nil
+}
+
 func createTempContextFile(execID string) (*os.File, error) {
 	name := fmt.Sprintf("uw-context-%s.tar.gz", execID)
 	tmpFile, err := os.CreateTemp(os.TempDir(), name)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -264,15 +264,15 @@ func copyDirFromRemoteAndUnzip(sshTarget, localDirectory, privateKey string) err
 }
 
 // zipRemoteDirectory takes an ssh target, and zips up the contents of that target to a returned in the remote /tmp
-func zipRemoteDirectory(sshTarget, privateKeyPath string) (string, error) {
+func zipRemoteDirectory(sshTarget, privateKeyPath string) (remoteArchiveLoc string, err error) {
 	sshTargetAndDir := strings.Split(sshTarget, ":")
 	if len(sshTargetAndDir) != 2 {
 		return "", fmt.Errorf("Failed to zip remote directory, expected both a remote target and directory in %s", sshTarget)
 	}
 
 	timestamp := time.Now().Unix()
-	outputFileName := fmt.Sprintf("/tmp/uw-context-%d.tar.gz", timestamp)
-	tarCmd := fmt.Sprintf("tar -czf %s -C %s .", outputFileName, sshTargetAndDir[1])
+	remoteArchiveLoc = fmt.Sprintf("/tmp/uw-context-%d.tar.gz", timestamp)
+	tarCmd := fmt.Sprintf("tar -czf %s -C %s .", remoteArchiveLoc, sshTargetAndDir[1])
 
 	sshCommand := exec.Command(
 		"ssh",
@@ -304,7 +304,7 @@ func zipRemoteDirectory(sshTarget, privateKeyPath string) (string, error) {
 		return "", fmt.Errorf("failed to unzip on remote host: %v", err)
 	}
 
-	return outputFileName, nil
+	return remoteArchiveLoc, nil
 }
 
 func createTempContextFile(execID string) (*os.File, error) {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/unweave/cli/config"
@@ -183,7 +184,7 @@ func handleCopySourceDir(isNew bool, e types.Exec, privKey string) error {
 			ui.Errorf("Failed to get active project path. Skipping copying source directory")
 			return fmt.Errorf("failed to get active project path: %v", err)
 		}
-		if err := copySourceAndUnzip(e.ID, dir, config.ProjectHostDir(), *e.Connection, privKey); err != nil {
+		if err := copyDirFromLocalAndUnzip(e.ID, dir, config.ProjectHostDir(), *e.Connection, privKey); err != nil {
 			return err
 		}
 	} else {
@@ -192,7 +193,7 @@ func handleCopySourceDir(isNew bool, e types.Exec, privKey string) error {
 	return nil
 }
 
-func copySourceAndUnzip(execID, rootDir, dstPath string, connectionInfo types.ConnectionInfo, privKeyPath string) error {
+func copyDirFromLocalAndUnzip(execID, rootDir, dstPath string, connectionInfo types.ConnectionInfo, privKeyPath string) error {
 	ui.Infof("🧳 Gathering context from %q", rootDir)
 
 	tmpFile, err := createTempContextFile(execID)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -226,7 +226,7 @@ func copyDirFromLocalAndUnzip(execID, rootDir, dstPath string, connectionInfo ty
 func copyDirFromRemoteAndUnzip(sshTarget, localDirectory, privateKey string) error {
 	ui.Infof("🧳 Gathering context from %q", sshTarget)
 
-	remotePath, err := zipRemoteDirectory(sshTarget, privateKey)
+	remotePath, err := tarRemoteDirectory(sshTarget, privateKey)
 	if err != nil {
 		return fmt.Errorf("Failed to zip the remote directory. Expected both a remote target and directory in %s", sshTarget)
 	}
@@ -263,8 +263,8 @@ func copyDirFromRemoteAndUnzip(sshTarget, localDirectory, privateKey string) err
 	return nil
 }
 
-// zipRemoteDirectory takes an ssh target, and zips up the contents of that target to a returned in the remote /tmp
-func zipRemoteDirectory(sshTarget, privateKeyPath string) (remoteArchiveLoc string, err error) {
+// tarRemoteDirectory takes an ssh target, and zips up the contents of that target to a returned in the remote /tmp
+func tarRemoteDirectory(sshTarget, privateKeyPath string) (remoteArchiveLoc string, err error) {
 	sshTargetAndDir := strings.Split(sshTarget, ":")
 	if len(sshTargetAndDir) != 2 {
 		return "", fmt.Errorf("Failed to zip remote directory, expected both a remote target and directory in %s", sshTarget)


### PR DESCRIPTION
This PR: 
- Acts as a fast follow to previous feedback.
- Implements remote to local directory copying via the archive process.
- Cleans up a case where the only key used was `id_rsa` or whatever key was specified in a user's extended SSH hosts config.
- Fixes a bug where users could not specify their own SSH key.
- Fixes a bug where directories would not be copied from local to remote via the archiving process consistently. 
- Some naming updates.
- Resolves UNW-192
```
🔄 Copying root@216.153.52.254:/home/unweave => /home/mmacheerpuppy/bar
🧳 Gathering context from "root@216.153.52.254:/home/unweave"
📦 Copying the archive of the remote path to the host...
🗜️ Unzipping the copied archive to the local directory...
✅  Copied root@216.153.52.254:/home/unweave => /home/mmacheerpuppy/bar
```