### PR TITLE
Allow passing a port when starting a new session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ tmp/
 
 .DS_Store
 .idea
+**/*.swp
+**/*.swo
 .unweave
 unweave
 cli

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -162,7 +162,7 @@ func ensureHosts(e types.Exec, identityFile string) {
 		ui.Infof("Run `unweave ls` to see the status of your session and try connecting manually.")
 		os.Exit(1)
 	}
-	if len(e.Network.Ports) == 0 {
+	if e.Network.Port == 0 {
 		ui.Errorf("❌ Something unexpected happened. No port info found for session %q", e.ID)
 		ui.Infof("Run `unweave ls` to see the status of your session. If this problem persists please contact an administrator.")
 		os.Exit(1)
@@ -175,7 +175,7 @@ func ensureHosts(e types.Exec, identityFile string) {
 		ui.Debugf("Failed to remove known_hosts entry: %v", err)
 	}
 
-	if err := ssh.AddHost("uw:"+e.ID, e.Network.Host, e.Network.User, e.Network.Ports[0], identityFile); err != nil {
+	if err := ssh.AddHost("uw:"+e.ID, e.Network.Host, e.Network.User, e.Network.Port, identityFile); err != nil {
 		ui.Debugf("Failed to add host to ssh config: %v", err)
 	}
 }

--- a/config/flags.go
+++ b/config/flags.go
@@ -34,6 +34,9 @@ var HDD int
 // NodeRegion is the region to use when creating a new session
 var NodeRegion = ""
 
+// InternalPort is the port that should be exposed as https
+var InternalPort int32
+
 // ProjectURI is the project slug with syntax `<owner>/<project` of the project to run
 // commands on. It is loaded from the saved config file and can be overridden with runtime flags.
 var ProjectURI = ""

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.6.1
-	github.com/unweave/unweave v0.0.0-20230616134539-e2b7003142ff
+	github.com/unweave/unweave v0.0.0-20230621145607-b079ce8b4089
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/unweave/unweave v0.0.0-20230616134539-e2b7003142ff h1:rpRqISyUDK5DOwz+9NiABvwaGy8PxTYy8Dkt9BqhydY=
-github.com/unweave/unweave v0.0.0-20230616134539-e2b7003142ff/go.mod h1:jSsvVJqqgH9Botkau2N4JI5W7z4JN9jG3pyywunr6w8=
+github.com/unweave/unweave v0.0.0-20230621145607-b079ce8b4089 h1:HBU0Nr5LLfJNWoWaDMbmOlQyTEwoCZfEIOVsWOHvocQ=
+github.com/unweave/unweave v0.0.0-20230621145607-b079ce8b4089/go.mod h1:jSsvVJqqgH9Botkau2N4JI5W7z4JN9jG3pyywunr6w8=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
 golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/main.go
+++ b/main.go
@@ -144,6 +144,8 @@ func init() {
 	codeCmd.Flags().IntVar(&config.Memory, "mem", 0, "Amount of RAM to allocate in GB, e.g., 16")
 	codeCmd.Flags().IntVar(&config.HDD, "hdd", 0, "Amount of hard-disk space to allocate in GB")
 	codeCmd.Flags().StringSliceVarP(&config.Volumes, "volume", "v", []string{}, "Mount a volume to the exec. e.g., -v <volume-name>:/data")
+	codeCmd.Flags().Int32VarP(&config.InternalPort, "port", "p", 0, "Port on the exec to expose as an https interface e.g. -p 8080")
+
 	rootCmd.AddCommand(codeCmd)
 
 	cpCmd := &cobra.Command{
@@ -255,6 +257,7 @@ func init() {
 	newCmd.Flags().IntVar(&config.Memory, "mem", 0, "Amount of RAM to allocate in GB, e.g., 16")
 	newCmd.Flags().IntVar(&config.HDD, "hdd", 0, "Amount of hard-disk space to allocate in GB")
 	newCmd.Flags().StringSliceVarP(&config.Volumes, "volume", "v", []string{}, "Mount a volume to the exec. e.g., -v <volume-name>:/data")
+	newCmd.Flags().Int32VarP(&config.InternalPort, "port", "p", 0, "Port on the exec to expose as an https interface e.g. -p 8080")
 
 	rootCmd.AddCommand(newCmd)
 
@@ -303,6 +306,7 @@ func init() {
 	sshCmd.Flags().IntVar(&config.Memory, "mem", 0, "Amount of RAM to allocate in GB, e.g., 16")
 	sshCmd.Flags().IntVar(&config.HDD, "hdd", 0, "Amount of hard-disk space to allocate in GB")
 	sshCmd.Flags().StringSliceVarP(&config.Volumes, "volume", "v", []string{}, "Mount a volume to newly created execs. e.g., -v <volume-name>:/data")
+	sshCmd.Flags().Int32VarP(&config.InternalPort, "port", "p", 0, "Port on the exec to expose as an https interface e.g. -p 8080")
 
 	rootCmd.AddCommand(sshCmd)
 

--- a/session/session.go
+++ b/session/session.go
@@ -127,6 +127,12 @@ func renderSessionCreated(exec *types.Exec) {
 		{Key: "Volumes", Value: ui.FormatVolumes(exec.Volumes)},
 	}
 
+	if exec.Network.HTTPService != nil {
+		results = append(results,
+			ui.ResultEntry{Key: "InternalPort", Value: fmt.Sprintf("%d", exec.Network.HTTPService.InternalPort)},
+		)
+	}
+
 	ui.ResultTitle("Session Created:")
 	ui.Result(results, ui.IndentWidth)
 	return


### PR DESCRIPTION
Produces an `ls` output like:
```
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Name                           vCPUs GPU           NumGPUs      HDD (GB)   Provider     Status            Connection String     Http Service                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 horn-distant-older-pocket      4     rtx_4000      1            50         unweave      running           root@216.153.51.162   https://exc-uxvezhnxunf0wlo.tenant-unweave-zak.unweave.dev (internal port: 8080)  

```