### PR TITLE
Allow running a command with ssh session

### DIFF
--- a/config/flags.go
+++ b/config/flags.go
@@ -53,6 +53,9 @@ var SSHPublicKeyPath = ""
 // SSHKeyName is the name of the SSH Key already configured in Unweave to use for a new or existing Exec.
 var SSHKeyName = ""
 
+// SSHConnectionOptions is the arguments you want to include when opening an SSH session.
+var SSHConnectionOptions []string
+
 // NoCopySource is a bool to denote whether to copy the source code to the session
 var NoCopySource = true
 

--- a/main.go
+++ b/main.go
@@ -307,6 +307,7 @@ func init() {
 	sshCmd.Flags().IntVar(&config.HDD, "hdd", 0, "Amount of hard-disk space to allocate in GB")
 	sshCmd.Flags().StringSliceVarP(&config.Volumes, "volume", "v", []string{}, "Mount a volume to newly created execs. e.g., -v <volume-name>:/data")
 	sshCmd.Flags().Int32VarP(&config.InternalPort, "port", "p", 0, "Port on the exec to expose as an https interface e.g. -p 8080")
+	sshCmd.Flags().StringSliceVar(&config.SSHConnectionOptions, "connection-option", []string{}, "SSH connection config to include e.g StrictHostKeyChecking=yes")
 
 	rootCmd.AddCommand(sshCmd)
 


### PR DESCRIPTION
When starting or joining an exec with ssh, allow passing `-- <some user command> <some args>` to the ssh command. This will execute the command on the exec and stream the logs back.

This changes the semantics of the -- separator from passing SSH connection options to being the user command to run.

The connection options can now be set using the repeatable `--connection-option=` flag. e.g.
`--connection-option=StrictHostKeyChecking=yes`

Note: for now, exiting the SSH session with CTRL-C will kill the user command. 

Example usage: 
```
unweave ssh -p 8080 -- python3 -m http.server 8080
```
.. this command will start a new ssh session, expose the internal port 8080 to an https service, and run a python http server on that port. 