### PR TITLE
Add exec command

### DIFF
--- a/cmd/session.go
+++ b/cmd/session.go
@@ -388,10 +388,10 @@ func SessionTerminate(cmd *cobra.Command, args []string) error {
 
 // sessionSelectSSHExecRef selects an exec id from all sessions in the Unweave environment or whether to create a new
 // provides an option to create a new Exec an error or exits if unrecoverable
-func sessionSelectSSHExecRef(cmd *cobra.Command, execRef string, allowNew bool) (execID string, isNewSession bool, err error) {
+func sessionSelectSSHExecRef(ctx context.Context, execRef string, allowNew bool) (execID string, isNewSession bool, err error) {
 	const newSessionOpt = "✨  Create a new session"
 
-	execs, err := getExecs(cmd.Context())
+	execs, err := getExecs(ctx)
 	if err != nil {
 		if e, ok := err.(*types.Error); ok {
 			uie := &ui.Error{Error: e}
@@ -410,7 +410,7 @@ func sessionSelectSSHExecRef(cmd *cobra.Command, execRef string, allowNew bool) 
 		cobraOpts, selectionIdByIdx = formatExecCobraOpts(execs, newSessionOpt)
 	}
 
-	execRef, err = renderCobraSelection(cmd.Context(), cobraOpts, selectionIdByIdx, "Select a session to connect to")
+	execRef, err = renderCobraSelection(ctx, cobraOpts, selectionIdByIdx, "Select a session to connect to")
 	if err != nil {
 		return "", false, err
 	}

--- a/config/flags.go
+++ b/config/flags.go
@@ -13,6 +13,9 @@ var BuildID = ""
 // CreateExec is used to denote whether to create a new exec when running commands that require a exec.
 var CreateExec = true
 
+// ExecAttach is used to determine if the exec command should stay attached to the exec after starting the command.
+var ExecAttach = false
+
 // GPUs is the number of GPUs to allocate for a gpuType.
 var GPUs int
 
@@ -52,6 +55,9 @@ var SSHPublicKeyPath = ""
 
 // SSHKeyName is the name of the SSH Key already configured in Unweave to use for a new or existing Exec.
 var SSHKeyName = ""
+
+// SSHConnectionOptions is the arguments you want to include when opening an SSH session.
+var SSHConnectionOptions []string
 
 // NoCopySource is a bool to denote whether to copy the source code to the session
 var NoCopySource = true

--- a/main.go
+++ b/main.go
@@ -185,9 +185,19 @@ func init() {
 		Use:     "exec [flags] -- [<command>]...",
 		RunE:    withValidProjectURI(cmd.Exec),
 	}
-	execCmd.Flags().StringSliceVar(&config.SSHConnectionOptions, "connection-option", []string{}, "SSH connection config to include e.g StrictHostKeyChecking=yes")
-	execCmd.Flags().BoolVarP(&config.ExecAttach, "interactive", "i", false, "Stay attached in an interactive terminal session to the exec after starting the command")
+	execCmd.Flags().StringVarP(&config.BuildID, "image", "i", "", "Build ID of the container image to use")
+	execCmd.Flags().StringVar(&config.Provider, "provider", "", "Provider to use")
+	execCmd.Flags().StringVar(&config.NodeRegion, "region", "", "Region to use, eg. `us_west_2`")
+	execCmd.Flags().IntVar(&config.GPUs, "gpus", 0, "Number of GPUs to allocate for a gpuType, e.g., 2")
+	execCmd.Flags().IntVar(&config.GPUMemory, "gpu-mem", 0, "Memory of GPU if applicable for a gpuType, e.g., 12")
+	execCmd.Flags().StringVar(&config.GPUType, "gpu-type", "", "Type of GPU to use, e.g., rtx_5000")
+	execCmd.Flags().IntVar(&config.CPUs, "cpus", 0, "Number of VCPUs to allocate, e.g., 4")
+	execCmd.Flags().IntVar(&config.Memory, "mem", 0, "Amount of RAM to allocate in GB, e.g., 16")
+	execCmd.Flags().IntVar(&config.HDD, "hdd", 0, "Amount of hard-disk space to allocate in GB")
+	execCmd.Flags().StringSliceVarP(&config.Volumes, "volume", "v", []string{}, "Mount a volume to the exec. e.g., -v <volume-name>:/data")
 	execCmd.Flags().Int32VarP(&config.InternalPort, "port", "p", 0, "Port on the exec to expose as an https interface e.g. -p 8080")
+	execCmd.Flags().BoolVar(&config.ExecAttach, "interactive", false, "Stay attached in an interactive terminal session to the exec after starting the command")
+	execCmd.Flags().StringSliceVar(&config.SSHConnectionOptions, "connection-option", []string{}, "SSH connection config to include e.g StrictHostKeyChecking=yes")
 
 	rootCmd.AddCommand(execCmd)
 

--- a/main.go
+++ b/main.go
@@ -179,13 +179,16 @@ func init() {
 			fmt.Println(config.Config.String())
 		},
 	})
-	rootCmd.AddCommand(&cobra.Command{
-		Use:     "exec",
-		Short:   "Execute a command serverlessly",
+	execCmd := &cobra.Command{
 		GroupID: groupDev,
-		Hidden:  true,
+		Short:   "Execute a command serverlessly",
+		Use:     "exec [flags] [session-name|id] -- [<command>]...",
 		RunE:    withValidProjectURI(cmd.Exec),
-	})
+	}
+	execCmd.Flags().StringSliceVar(&config.SSHConnectionOptions, "connection-option", []string{}, "SSH connection config to include e.g StrictHostKeyChecking=yes")
+	execCmd.Flags().BoolVarP(&config.ExecAttach, "interactive", "i", false, "Stay attached in an interactive terminal session to the exec after starting the command")
+
+	rootCmd.AddCommand(execCmd)
 
 	linkCmd := &cobra.Command{
 		Use:     "link [project-id]",

--- a/main.go
+++ b/main.go
@@ -182,11 +182,12 @@ func init() {
 	execCmd := &cobra.Command{
 		GroupID: groupDev,
 		Short:   "Execute a command serverlessly",
-		Use:     "exec [flags] [session-name|id] -- [<command>]...",
+		Use:     "exec [flags] -- [<command>]...",
 		RunE:    withValidProjectURI(cmd.Exec),
 	}
 	execCmd.Flags().StringSliceVar(&config.SSHConnectionOptions, "connection-option", []string{}, "SSH connection config to include e.g StrictHostKeyChecking=yes")
 	execCmd.Flags().BoolVarP(&config.ExecAttach, "interactive", "i", false, "Stay attached in an interactive terminal session to the exec after starting the command")
+	execCmd.Flags().Int32VarP(&config.InternalPort, "port", "p", 0, "Port on the exec to expose as an https interface e.g. -p 8080")
 
 	rootCmd.AddCommand(execCmd)
 

--- a/ssh/connect.go
+++ b/ssh/connect.go
@@ -12,7 +12,7 @@ import (
 	"github.com/unweave/unweave/api/types"
 )
 
-func Connect(ctx context.Context, connectionInfo types.ExecNetwork, prvKeyPath string, args []string) error {
+func Connect(ctx context.Context, connectionInfo types.ExecNetwork, prvKeyPath string, args []string, command []string) error {
 	overrideUserKnownHostsFile := false
 	overrideStrictHostKeyChecking := false
 
@@ -36,9 +36,15 @@ func Connect(ctx context.Context, connectionInfo types.ExecNetwork, prvKeyPath s
 		args = append(args, "-o", "StrictHostKeyChecking=no")
 	}
 
+	sshArgs := append(args, fmt.Sprintf("%s@%s", connectionInfo.User, connectionInfo.Host))
+
+	if len(command) != 0 {
+		sshArgs = append(sshArgs, command...)
+	}
+
 	sshCommand := exec.Command(
 		"ssh",
-		append(args, fmt.Sprintf("%s@%s", connectionInfo.User, connectionInfo.Host))...,
+		sshArgs...,
 	)
 
 	ui.Debugf("Running SSH command: %s", strings.Join(sshCommand.Args, " "))


### PR DESCRIPTION
Add command that will run on the remote exec.
By default the ssh session will detach and leave the command running using nohup. The Pid of the command will be stored in pid.nohup file. We can use this later to stop the exec command if we need to.

Include the `--interactive`/`-i` flag to stay attached to the remote after running the exec command.

Also:
- share some of the connection logic between SSH and Exec commands by introducing an interface that allows the two commands to differ.

Example: 
```bash
unweave exec -p 8080 -- python3 -m http.server 8080
```