### PR TITLE
Add logs command to print logs from exec 

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -59,7 +59,7 @@ func (e *execCommandFlow) parseArgs(cmd *cobra.Command, args []string) execCmdAr
 		escaped := strings.ReplaceAll(strings.Join(execArgs.userCommand, " "), "\"", "\\\"")
 
 		execArgs.execCommand = []string{"nohup", "bash", "-c", "\"", escaped, "\""}
-		execArgs.execCommand = append(execArgs.execCommand, ">", "exec.log", "2>&1", "&", "echo", "$!", ">", "./pid.nohup", "&&", "sleep", "1")
+		execArgs.execCommand = append(execArgs.execCommand, ">", execLogFile, "2>&1", "&", "echo", "$!", ">", "./pid.nohup", "&&", "sleep", "1")
 	}
 
 	return execArgs

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/unweave/cli/config"
+	"github.com/unweave/cli/ssh"
+	"github.com/unweave/cli/ui"
+)
+
+const execLogFile = "exec.log"
+
+func Logs(cmd *cobra.Command, args []string) error {
+
+	if len(args) == 0 {
+		const errMsg = "❌ Invalid arguments. Missing session-id or name. " +
+			"See `unweave logs --help` for more information"
+		ui.Errorf(errMsg)
+		os.Exit(1)
+	}
+
+	if len(args) > 1 {
+		const errMsg = "❌ Invalid arguments. You must pass the session-id or name only. " +
+			"See `unweave logs --help` for more information"
+		ui.Errorf(errMsg)
+		os.Exit(1)
+	}
+
+	execRef := args[0]
+	ctx := cmd.Context()
+
+	e, err := getExecByNameOrID(ctx, execRef)
+	if err != nil {
+		return errors.New("Could not find session by name or ID")
+	}
+
+	command := []string{"tail"}
+
+	if config.FollowLogs {
+		command = append(command, "-f")
+	}
+
+	command = append(command, execLogFile)
+
+	prvKey := config.SSHPrivateKeyPath
+	if err := ssh.Connect(ctx, e.Network, prvKey, config.SSHConnectionOptions, command); err != nil {
+		ui.Errorf("%s", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/config/flags.go
+++ b/config/flags.go
@@ -64,3 +64,8 @@ var NoCopySource = true
 
 // Volumes is a list of volumes to mount to the session
 var Volumes []string
+
+// FollowLogs denotes if the logs command should stay attached
+// and print logs as they come in. Default false, which means
+// print only the logs received so far.
+var FollowLogs = false

--- a/main.go
+++ b/main.go
@@ -201,6 +201,17 @@ func init() {
 
 	rootCmd.AddCommand(execCmd)
 
+	logsCmd := &cobra.Command{
+		GroupID: groupDev,
+		Short:   "Print logs from an exec",
+		Use:     "logs [flags] [session-id|name]",
+		RunE:    withValidProjectURI(cmd.Logs),
+	}
+	logsCmd.Flags().StringSliceVar(&config.SSHConnectionOptions, "connection-option", []string{}, "SSH connection config to include e.g StrictHostKeyChecking=yes")
+	logsCmd.Flags().BoolVarP(&config.FollowLogs, "follow", "f", false, "Stream logs as they are created")
+
+	rootCmd.AddCommand(logsCmd)
+
 	linkCmd := &cobra.Command{
 		Use:     "link [project-id]",
 		Aliases: []string{"init"}, // this is temp


### PR DESCRIPTION
Include a -f/--follow flag that will steam the logs back from the exec.