### PR TITLE
feat: --debug prints HTTP request/responses

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -36,8 +36,10 @@ type Client struct {
 
 func NewClient(cfg Config) *Client {
 	c := &Client{
-		cfg:    &cfg,
-		client: &http.Client{},
+		cfg: &cfg,
+		client: &http.Client{
+			Transport: newLoggedTransport(http.DefaultTransport),
+		},
 	}
 	c.Build = &BuildService{client: c}
 	c.Provider = &ProviderService{client: c}

--- a/client/debug.go
+++ b/client/debug.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/unweave/cli/vars"
+)
+
+type loggedRoundTripper struct {
+	rt http.RoundTripper
+}
+
+func (c *loggedRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if vars.Debug {
+		fmt.Printf("=> %s %s\n", request.Method, request.URL.String())
+	}
+	startTime := time.Now()
+	response, err := c.rt.RoundTrip(request)
+	duration := time.Since(startTime)
+	if vars.Debug {
+		if err != nil {
+			fmt.Printf("<= (%s) ERROR! %s\n", duration.String(), err.Error())
+		} else {
+			fmt.Printf("<= (%s) %s\n", duration.String(), response.Status)
+		}
+	}
+	return response, err
+}
+
+// newLoggedTransport takes an http.RoundTripper and returns a new one that logs requests and responses
+func newLoggedTransport(rt http.RoundTripper) http.RoundTripper {
+	return &loggedRoundTripper{rt: rt}
+}


### PR DESCRIPTION
### What?

Very quick change to be able to see context around HTTP requests and responses when `--debug` is set.

### How?

Custom the HTTP transport to log requests and responses. We are using `fmt.Printf` rather than `ui.Debug` because we don't want to word-wrap URLs.

### Snapshot

<img width="1261" alt="CleanShot 2023-07-13 at 16 06 45@2x" src="https://github.com/unweave/cli/assets/1005/6888dee0-8c36-40ac-9670-18f797cf81a0">
