### PR TITLE
Add endpoint versions

### DIFF
--- a/client/endpoints.go
+++ b/client/endpoints.go
@@ -12,7 +12,7 @@ type EndpointService struct {
 	client *Client
 }
 
-func (s *EndpointService) List(ctx context.Context, userID, projectID string) ([]types.Endpoint, error) {
+func (s *EndpointService) List(ctx context.Context, userID, projectID string) ([]types.EndpointListItem, error) {
 	uri := fmt.Sprintf("projects/%s/%s/endpoints", userID, projectID)
 	req, err := s.client.NewAuthorizedRestRequest(Get, uri, nil, nil)
 	if err != nil {

--- a/client/endpoints.go
+++ b/client/endpoints.go
@@ -27,8 +27,11 @@ func (s *EndpointService) List(ctx context.Context, userID, projectID string) ([
 	return endpoints.Endpoints, nil
 }
 
-func (s *EndpointService) Create(ctx context.Context, userID, projectID, execID string) (types.Endpoint, error) {
-	request := types.EndpointCreate{ExecID: execID}
+func (s *EndpointService) Create(ctx context.Context, userID, projectID, execID, name string) (types.Endpoint, error) {
+	request := types.EndpointCreate{
+		ExecID: execID,
+		Name:   name,
+	}
 
 	uri := fmt.Sprintf("projects/%s/%s/endpoints", userID, projectID)
 	req, err := s.client.NewAuthorizedRestRequest(Post, uri, nil, request)
@@ -91,4 +94,25 @@ func (s *EndpointService) EndpointCheckStatus(ctx context.Context, userID, proje
 	}
 
 	return status, nil
+}
+
+func (s *EndpointService) CreateVersion(ctx context.Context, userID, projectID, endpointID, execID string) (types.EndpointVersion, error) {
+	uri := fmt.Sprintf("projects/%s/%s/endpoints/%s/version", userID, projectID, endpointID)
+
+	body := types.EndpointVersionCreate{
+		ExecID:  execID,
+		Promote: true,
+	}
+
+	req, err := s.client.NewAuthorizedRestRequest(Post, uri, nil, body)
+	if err != nil {
+		return types.EndpointVersion{}, err
+	}
+
+	response := types.EndpointVersion{}
+	if err = s.client.ExecuteRest(ctx, req, &response); err != nil {
+		return types.EndpointVersion{}, err
+	}
+
+	return response, nil
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -102,35 +102,31 @@ func (d *deployCommandFlow) onSshCommandFinish(ctx context.Context, execID strin
 			return fmt.Errorf("deploy: %w", err)
 		}
 
-		ui.Infof("✅ Created endpint %q for exec", endpoint.ID)
-		ui.Infof("🔗 Access endpoint at:")
-		ui.Infof("    https://%s", endpoint.HTTPEndpoint)
+		ui.Infof("✅ Endpoint created: %q", endpoint.ID)
+		ui.Infof("https://%s", endpoint.HTTPAddress)
 
-		return nil
+		end.ID = endpoint.ID
 	}
 
-	ui.Debugf("endpoint found, creating version, name: %q, id: %q", d.endpointName, end.ID)
+	ui.Debugf("creating version, name: %q, id: %q", d.endpointName, end.ID)
 
 	version, err := uwc.Endpoints.CreateVersion(ctx, owner, project, end.ID, execID)
 	if err != nil {
 		return fmt.Errorf("create version: %w", err)
 	}
 
-	ui.Infof("✅ Created endpint version %q for exec", version.ID)
-	ui.Infof("🔗 Access endpoint at:")
-	ui.Infof("    https://%s", end.HTTPEndpoint)
-	ui.Infof("🔗 Access version at:")
-	ui.Infof("    https://%s", version.HTTPEndpoint)
+	ui.Infof("✅ Version created %q", version.ID)
+	ui.Infof("https://%s", version.HTTPAddress)
 
 	return nil
 }
 
-func findEndpoint(name string, ends []types.Endpoint) (types.Endpoint, bool) {
+func findEndpoint(name string, ends []types.EndpointListItem) (types.EndpointListItem, bool) {
 	for _, end := range ends {
 		if strings.EqualFold(name, end.Name) || strings.EqualFold(name, end.ID) {
 			return end, true
 		}
 	}
 
-	return types.Endpoint{}, false
+	return types.EndpointListItem{}, false
 }

--- a/cmd/endpoints.go
+++ b/cmd/endpoints.go
@@ -41,8 +41,7 @@ func EndpointList(cmd *cobra.Command, args []string) error {
 
 	for _, endpoint := range endpoints {
 		ui.Infof("id: %s", endpoint.ID)
-		ui.Infof("exec id: %s", endpoint.ExecID)
-		ui.Infof("http: %s\n", endpoint.HTTPEndpoint)
+		ui.Infof("http: %s\n", endpoint.HTTPAddress)
 	}
 
 	return nil

--- a/cmd/endpoints.go
+++ b/cmd/endpoints.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/unweave/cli/config"
 	"github.com/unweave/cli/ui"
@@ -14,7 +16,9 @@ func EndpointCreate(cmd *cobra.Command, args []string) error {
 
 	uwc := config.InitUnweaveClient()
 
-	endpoint, err := uwc.Endpoints.Create(ctx, owner, projectName, execID)
+	name := strings.ReplaceAll(config.EndpointName, "_", "-")
+
+	endpoint, err := uwc.Endpoints.Create(ctx, owner, projectName, execID, name)
 	if err != nil {
 		return err
 	}

--- a/config/flags.go
+++ b/config/flags.go
@@ -22,6 +22,10 @@ var SpecName string
 // Command is the user supplied command that should be run in the exec.
 var Command string
 
+// EndpointName is the name of the endpoint we operate on when calling deploy
+// or create if it doesn't exist.
+var EndpointName string
+
 // GPUs is the number of GPUs to allocate for a gpuType.
 var GPUs int
 

--- a/main.go
+++ b/main.go
@@ -523,6 +523,7 @@ func init() {
 	deployCmd.Flags().StringVar(&config.Command, "cmd", "", "Command to run in the deploy [required]")
 	deployCmd.Flags().StringSliceVarP(&config.Volumes, "volume", "v", []string{}, "Mount a volume to the exec. e.g., -v <volume-name>:/data")
 	deployCmd.Flags().Int32VarP(&config.InternalPort, "port", "p", 8080, "Port on the exec to expose as an https interface e.g. -p 8080")
+	deployCmd.Flags().StringVar(&config.EndpointName, "endpoint", "", "name of the endpoint to deploy")
 	deployCmd.Flags().StringSliceVar(&config.SSHConnectionOptions, "connection-option", []string{}, "SSH connection config to include e.g StrictHostKeyChecking=yes")
 
 	rootCmd.AddCommand(deployCmd)


### PR DESCRIPTION
Update the deploy command to take an endpoint name, if the endpoint already exists, create a new exec and attach it as a version to the endpoint. Promote that version to the primary.