### PR TITLE
feat: Allow passing --json to commands

### DIFF
--- a/cmd/endpoints.go
+++ b/cmd/endpoints.go
@@ -23,7 +23,12 @@ func EndpointCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ui.Infof("endpoint: %s", endpoint.ID)
+	if config.OutputJSON {
+		ui.JSON(endpoint)
+	} else {
+		ui.Infof("endpoint: %s", endpoint.ID)
+	}
+
 	return nil
 }
 
@@ -37,6 +42,11 @@ func EndpointList(cmd *cobra.Command, args []string) error {
 	endpoints, err := uwc.Endpoints.List(ctx, owner, projectName)
 	if err != nil {
 		return err
+	}
+
+	if config.OutputJSON {
+		ui.JSON(endpoints)
+		return nil
 	}
 
 	for _, endpoint := range endpoints {

--- a/cmd/evals.go
+++ b/cmd/evals.go
@@ -19,7 +19,11 @@ func EvalCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ui.Infof("eval: %s", eval.ID)
+	if config.OutputJSON {
+		ui.JSON(eval)
+	} else {
+		ui.Infof("eval: %s", eval.ID)
+	}
 	return nil
 }
 
@@ -33,6 +37,11 @@ func EvalList(cmd *cobra.Command, args []string) error {
 	evals, err := uwc.Evals.List(ctx, owner, projectName)
 	if err != nil {
 		return err
+	}
+
+	if config.OutputJSON {
+		ui.JSON(evals)
+		return nil
 	}
 
 	for _, eval := range evals {

--- a/cmd/session.go
+++ b/cmd/session.go
@@ -206,23 +206,27 @@ func SessionList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(sessions) > 0 {
-		renderSessionListWithSessions(sessions)
-	} else {
-		renderSessionListNoSessions()
-	}
+	renderSessionListWithSessions(sessions)
 
 	return nil
-}
-
-func renderSessionListNoSessions() {
-	ui.Infof("No active sessions")
 }
 
 func renderSessionListWithSessions(sessions []types.Exec) {
 	sort.Slice(sessions, func(i, j int) bool {
 		return sessions[i].Name < sessions[j].Name
 	})
+
+	if config.OutputJSON {
+		if sessions == nil {
+			sessions = []types.Exec{}
+		}
+		ui.JSON(sessions)
+		return
+	}
+
+	if len(sessions) == 0 {
+		ui.Infof("No active sessions")
+	}
 
 	// EITHER min length of title + 5 for padding OR the max field length + 5 for padding
 	cols := []ui.Column{

--- a/config/flags.go
+++ b/config/flags.go
@@ -79,3 +79,6 @@ var Volumes []string
 // and print logs as they come in. Default false, which means
 // print only the logs received so far.
 var FollowLogs = false
+
+// OutputJSON denotes if the output should be in JSON format
+var OutputJSON = false

--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func init() {
 
 	flags.StringVarP(&config.SSHKeyName, "key", "k", "", "Name of the SSH key to use")
 	flags.StringVar(&config.SSHPublicKeyPath, "pub", "", "Path to the SSH public key to use")
+	flags.BoolVar(&config.OutputJSON, "json", false, "Output JSON instead of human-readable text")
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use:     "build [path]",

--- a/ui/json.go
+++ b/ui/json.go
@@ -1,0 +1,13 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+)
+
+func JSON(v any) {
+	err := json.NewEncoder(os.Stdout).Encode(v)
+	if err != nil {
+		Errorf("failed to encode output: %s", err.Error())
+	}
+}


### PR DESCRIPTION
In order to be able to have scripts that rely on the output of other commands.

Simple example:

```bash
unweave ls --json | jq -r '.[] | .id' | xargs unweave terminate
```