### PR TITLE
feat: --json support for deploy

### DIFF
--- a/client/debug.go
+++ b/client/debug.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/unweave/cli/ui"
 	"github.com/unweave/cli/vars"
 )
 
@@ -14,16 +15,16 @@ type loggedRoundTripper struct {
 
 func (c *loggedRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	if vars.Debug {
-		fmt.Printf("=> %s %s\n", request.Method, request.URL.String())
+		fmt.Fprintf(ui.Output, "=> %s %s\n", request.Method, request.URL.String())
 	}
 	startTime := time.Now()
 	response, err := c.rt.RoundTrip(request)
 	duration := time.Since(startTime)
 	if vars.Debug {
 		if err != nil {
-			fmt.Printf("<= (%s) ERROR! %s\n", duration.String(), err.Error())
+			fmt.Fprintf(ui.Output, "<= (%s) ERROR! %s\n", duration.String(), err.Error())
 		} else {
-			fmt.Printf("<= (%s) %s\n", duration.String(), response.Status)
+			fmt.Fprintf(ui.Output, "<= (%s) %s\n", duration.String(), response.Status)
 		}
 	}
 	return response, err

--- a/client/endpoints.go
+++ b/client/endpoints.go
@@ -75,6 +75,7 @@ func (s *EndpointService) RunEvalCheck(ctx context.Context, userID, projectID, e
 		return err
 	}
 
+	ui.JSON(response)
 	ui.Infof("check id: %s", response.CheckID)
 
 	return nil

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -118,6 +118,11 @@ func (d *deployCommandFlow) onSshCommandFinish(ctx context.Context, execID strin
 	ui.Infof("✅ Version created %q", version.ID)
 	ui.Infof("https://%s", version.HTTPAddress)
 
+	ui.JSON(map[string]any{
+		"endpoint": end,
+		"version":  version,
+	})
+
 	return nil
 }
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -86,6 +86,8 @@ func (e *execCommandFlow) getExec(cmd *cobra.Command, execCmd execCmdArgs) (chan
 func (e *execCommandFlow) onSshCommandFinish(ctx context.Context, execID string) error {
 	ui.Infof("Session %q exited. Use 'unweave terminate' to stop the session.", execID)
 
+	ui.JSON(map[string]any{"id": execID})
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,12 @@ var (
 		Args:          cobra.MinimumNArgs(0),
 		SilenceUsage:  false,
 		SilenceErrors: false,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if config.OutputJSON {
+				ui.Output = os.Stderr
+				ui.OutputJSON = true
+			}
+		},
 	}
 )
 

--- a/ui/json.go
+++ b/ui/json.go
@@ -6,6 +6,10 @@ import (
 )
 
 func JSON(v any) {
+	if !OutputJSON {
+		return
+	}
+
 	err := json.NewEncoder(os.Stdout).Encode(v)
 	if err != nil {
 		Errorf("failed to encode output: %s", err.Error())

--- a/ui/print.go
+++ b/ui/print.go
@@ -18,14 +18,17 @@ var (
 	warningColor   = lipgloss.NewStyle().Foreground(lipgloss.Color("#F5C237"))
 )
 
+var Output = os.Stdout
+var OutputJSON = false
+
 func Attentionf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
-	fmt.Println(attentionColor.Render(wordwrap.String(s, MaxOutputLineLength)))
+	fmt.Fprintln(Output, attentionColor.Render(wordwrap.String(s, MaxOutputLineLength)))
 }
 
 func Errorf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
-	fmt.Println(errorColor.Render(wordwrap.String(s, MaxOutputLineLength)))
+	fmt.Fprintln(Output, errorColor.Render(wordwrap.String(s, MaxOutputLineLength)))
 }
 
 // Fatal prints an error message. It checks is the error is a types.Error and prints
@@ -33,32 +36,32 @@ func Errorf(format string, a ...any) {
 //
 // You should use this function instead of Errorf (which is being deprecated).
 func Fatal(msg string, err error) {
-	fmt.Println(errorColor.Render(wordwrap.String(msg, MaxOutputLineLength)))
+	fmt.Fprintln(Output, errorColor.Render(wordwrap.String(msg, MaxOutputLineLength)))
 	var e *types.Error
 	if errors.As(err, &e) {
 		if e.Code == 401 {
-			fmt.Println("Unauthorized. Please login with `unweave login`")
+			fmt.Fprintln(Output, "Unauthorized. Please login with `unweave login`")
 			os.Exit(1)
 		}
 		uie := &Error{Error: e}
-		fmt.Println(uie.Verbose())
+		fmt.Fprintln(Output, uie.Verbose())
 	}
 	os.Exit(1)
 }
 
 func Infof(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
-	fmt.Println(wordwrap.String(s, MaxOutputLineLength))
+	fmt.Fprintln(Output, wordwrap.String(s, MaxOutputLineLength))
 }
 
 func Successf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
-	fmt.Println(successColor.Render(wordwrap.String(s, MaxOutputLineLength)))
+	fmt.Fprintln(Output, successColor.Render(wordwrap.String(s, MaxOutputLineLength)))
 }
 
 func Debugf(format string, a ...any) {
 	s := fmt.Sprintf(format, a...)
 	if vars.Debug {
-		fmt.Println(wordwrap.String(s, MaxOutputLineLength))
+		fmt.Fprintln(Output, wordwrap.String(s, MaxOutputLineLength))
 	}
 }


### PR DESCRIPTION
Enabling `--json` for deploy.

I also tweaked UI so, when `--json` is enabled, all the regular logging happens in `STDERR` and when it's disabled `ui.JSON` does nothing.